### PR TITLE
Add support for updating service instances

### DIFF
--- a/cmd/svcat/instance/set_cmd.go
+++ b/cmd/svcat/instance/set_cmd.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instance
+
+import (
+	"fmt"
+
+	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
+	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/output"
+	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/parameters"
+	"github.com/kubernetes-incubator/service-catalog/pkg/svcat/service-catalog"
+	"github.com/spf13/cobra"
+)
+
+type setCmd struct {
+	*command.Namespaced
+	*command.Waitable
+
+	instanceName      string
+	planName          string
+	rawParams         []string
+	jsonParams        string
+	params            interface{}
+	areParamsProvided bool
+	rawSecrets        []string
+	secrets           map[string]string
+}
+
+// NewSetCmd builds a "svcat set instance" command
+func NewSetCmd(cxt *command.Context) *cobra.Command {
+	setCmd := &setCmd{
+		Namespaced: command.NewNamespaced(cxt),
+		Waitable:   command.NewWaitable(),
+	}
+	cmd := &cobra.Command{
+		Use:   "instance NAME [flags]",
+		Short: "Configure a provisioned service instance",
+		Example: command.NormalizeExamples(`
+  svcat set instance wordpress-mysql-instance --plan free
+  svcat set instance wordpress-mysql-instance --plan free -s mysecret[dbparams]
+  svcat set instance secure-instance --plan secureDB --params-json '{
+    "encrypt" : true,
+    "firewallRules" : [
+        {
+            "name": "AllowSome",
+            "startIPAddress": "75.70.113.50",
+            "endIPAddress" : "75.70.113.131"
+        }
+    ]
+  }'
+`),
+		PreRunE: command.PreRunE(setCmd),
+		RunE:    command.RunE(setCmd),
+	}
+	setCmd.AddNamespaceFlags(cmd.Flags(), false)
+	cmd.Flags().StringVar(&setCmd.planName, "plan", "",
+		"The plan name (Required)")
+	cmd.Flags().StringSliceVarP(&setCmd.rawParams, "param", "p", nil,
+		"Additional parameter to use when updating the service instance, format: NAME=VALUE. Cannot be combined with --params-json, Sensitive information should be placed in a secret and specified with --secret")
+	cmd.Flags().StringSliceVarP(&setCmd.rawSecrets, "secret", "s", nil,
+		"Additional parameter, whose value is stored in a secret, to use when updating the service instance, format: SECRET[KEY]")
+	cmd.Flags().StringVar(&setCmd.jsonParams, "params-json", "",
+		"Additional parameters to use when updating the service instance, provided as a JSON object. Cannot be combined with --param")
+	setCmd.AddWaitFlags(cmd)
+
+	return cmd
+}
+
+func (c *setCmd) Validate(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("an instance name is required")
+	}
+	c.instanceName = args[0]
+
+	var err error
+
+	if c.jsonParams != "" && len(c.rawParams) > 0 {
+		return fmt.Errorf("--params-json cannot be used with --param")
+	}
+
+	if c.jsonParams != "" {
+		c.params, err = parameters.ParseVariableJSON(c.jsonParams)
+		if err != nil {
+			return fmt.Errorf("invalid --params-json value (%s)", err)
+		}
+		c.areParamsProvided = true
+	} else if len(c.rawParams) > 0 {
+		c.params, err = parameters.ParseVariableAssignments(c.rawParams)
+		if err != nil {
+			return fmt.Errorf("invalid --param value (%s)", err)
+		}
+		c.areParamsProvided = true
+	}
+
+	c.secrets, err = parameters.ParseKeyMaps(c.rawSecrets)
+	if err != nil {
+		return fmt.Errorf("invalid --secret value (%s)", err)
+	}
+
+	return nil
+}
+
+func (c *setCmd) Run() error {
+	err := c.configureCmdProperties()
+	if err != nil {
+		return err
+	}
+
+	return c.Update()
+}
+
+func (c *setCmd) Update() error {
+	instance, err := c.App.UpdateInstance(c.Namespace, c.instanceName, c.planName, c.params, c.secrets)
+	if err != nil {
+		return err
+	}
+
+	if c.Wait {
+		fmt.Fprintln(c.Output, "Waiting for the instance to be updated...")
+		finalInstance, err := c.App.WaitForInstance(instance.Namespace, instance.Name, c.Interval, c.Timeout)
+		if err == nil {
+			instance = finalInstance
+		}
+
+		// Always print the instance because the update did succeed,
+		// and just print any errors that occurred while polling
+		output.WriteInstanceDetails(c.Output, instance)
+		return err
+	}
+
+	output.WriteInstanceDetails(c.Output, instance)
+	return nil
+}
+
+func (c *setCmd) configureCmdProperties() error {
+	instance, err := c.App.RetrieveInstance(c.Namespace, c.instanceName)
+	if err != nil {
+		return nil
+	}
+
+	if c.planName == "" {
+		c.planName = instance.Spec.PlanReference.ClusterServicePlanExternalName
+	}
+
+	if !c.areParamsProvided {
+		c.params = servicecatalog.BuildParametersFromInstance(instance.Spec.Parameters)
+	}
+
+	if len(c.secrets) == 0 {
+		c.secrets = servicecatalog.BuildMapFromInstanceSecretRefs(instance.Spec.ParametersFrom)
+	}
+
+	return nil
+}

--- a/cmd/svcat/instance/set_cmd.go
+++ b/cmd/svcat/instance/set_cmd.go
@@ -70,7 +70,7 @@ func NewSetCmd(cxt *command.Context) *cobra.Command {
 	cmd.Flags().StringVar(&setCmd.planName, "plan", "",
 		"The plan name (Required)")
 	cmd.Flags().StringSliceVarP(&setCmd.rawParams, "param", "p", nil,
-		"Additional parameter to use when updating the service instance, format: NAME=VALUE. Cannot be combined with --params-json, Sensitive information should be placed in a secret and specified with --secret")
+		"Replaces existing parameters on the service instance, format: NAME=VALUE. Cannot be combined with --params-json, Sensitive information should be placed in a secret and specified with --secret")
 	cmd.Flags().StringSliceVarP(&setCmd.rawSecrets, "secret", "s", nil,
 		"Additional parameter, whose value is stored in a secret, to use when updating the service instance, format: SECRET[KEY]")
 	cmd.Flags().StringVar(&setCmd.jsonParams, "params-json", "",
@@ -149,7 +149,7 @@ func (c *setCmd) Update() error {
 func (c *setCmd) configureCmdProperties() error {
 	instance, err := c.App.RetrieveInstance(c.Namespace, c.instanceName)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	if c.planName == "" {

--- a/cmd/svcat/instance/touch_cmd.go
+++ b/cmd/svcat/instance/touch_cmd.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 
 	"github.com/kubernetes-incubator/service-catalog/cmd/svcat/command"
+	"github.com/kubernetes-incubator/service-catalog/pkg/svcat/service-catalog"
 	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 type touchInstanceCmd struct {
@@ -56,6 +58,27 @@ func (c *touchInstanceCmd) Validate(args []string) error {
 }
 
 func (c *touchInstanceCmd) Run() error {
+	instance, err := c.App.RetrieveInstance(c.Namespace, c.name)
+	if err != nil {
+		return nil
+	}
+
+	planName := instance.Spec.PlanReference.ClusterServicePlanExternalName
+	params := servicecatalog.BuildParametersFromInstance(instance.Spec.Parameters)
+	secrets := servicecatalog.BuildMapFromInstanceSecretRefs(instance.Spec.ParametersFrom)
+
 	const retries = 3
-	return c.App.TouchInstance(c.Namespace, c.name, retries)
+	for j := 0; j < retries; j++ {
+		c.App.UpdateInstance(c.Namespace, c.name, planName, params, secrets)
+		if err == nil {
+			return nil
+		}
+		// if we didn't get a conflict, no idea what happened
+		if !apierrors.IsConflict(err) {
+			return fmt.Errorf("could not touch instance (%s)", err)
+		}
+	}
+
+	// conflict after `retries` tries
+	return fmt.Errorf("could not sync service broker after %d tries", retries)
 }

--- a/cmd/svcat/main.go
+++ b/cmd/svcat/main.go
@@ -119,6 +119,7 @@ func buildRootCommand(cxt *command.Context) *cobra.Command {
 
 	cmd.AddCommand(newCreateCmd(cxt))
 	cmd.AddCommand(newGetCmd(cxt))
+	cmd.AddCommand(newSetCmd(cxt))
 	cmd.AddCommand(newDescribeCmd(cxt))
 	cmd.AddCommand(broker.NewRegisterCmd(cxt))
 	cmd.AddCommand(broker.NewDeregisterCmd(cxt))
@@ -169,6 +170,16 @@ func newGetCmd(cxt *command.Context) *cobra.Command {
 	cmd.AddCommand(class.NewGetCmd(cxt))
 	cmd.AddCommand(instance.NewGetCmd(cxt))
 	cmd.AddCommand(plan.NewGetCmd(cxt))
+
+	return cmd
+}
+
+func newSetCmd(cxt *command.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Configure a specific resource",
+	}
+	cmd.AddCommand(instance.NewSetCmd(cxt))
 
 	return cmd
 }

--- a/cmd/svcat/testdata/output/completion-bash.txt
+++ b/cmd/svcat/testdata/output/completion-bash.txt
@@ -959,6 +959,70 @@ _svcat_register()
     noun_aliases=()
 }
 
+_svcat_set_instance()
+{
+    last_command="svcat_set_instance"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--interval=")
+    local_nonpersistent_flags+=("--interval=")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--namespace=")
+    flags+=("--param=")
+    two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--param=")
+    flags+=("--params-json=")
+    local_nonpersistent_flags+=("--params-json=")
+    flags+=("--plan=")
+    local_nonpersistent_flags+=("--plan=")
+    flags+=("--secret=")
+    two_word_flags+=("-s")
+    local_nonpersistent_flags+=("--secret=")
+    flags+=("--timeout=")
+    local_nonpersistent_flags+=("--timeout=")
+    flags+=("--wait")
+    local_nonpersistent_flags+=("--wait")
+    flags+=("--context=")
+    flags+=("--kubeconfig=")
+    flags+=("--logtostderr")
+    flags+=("--v=")
+    two_word_flags+=("-v")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_svcat_set()
+{
+    last_command="svcat_set"
+    commands=()
+    commands+=("instance")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--context=")
+    flags+=("--kubeconfig=")
+    flags+=("--logtostderr")
+    flags+=("--v=")
+    two_word_flags+=("-v")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _svcat_sync_broker()
 {
     last_command="svcat_sync_broker"
@@ -1130,6 +1194,7 @@ _svcat_root_command()
     commands+=("marketplace")
     commands+=("provision")
     commands+=("register")
+    commands+=("set")
     commands+=("sync")
     commands+=("touch")
     commands+=("unbind")

--- a/cmd/svcat/testdata/output/completion-zsh.txt
+++ b/cmd/svcat/testdata/output/completion-zsh.txt
@@ -1093,6 +1093,70 @@ _svcat_register()
     noun_aliases=()
 }
 
+_svcat_set_instance()
+{
+    last_command="svcat_set_instance"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--interval=")
+    local_nonpersistent_flags+=("--interval=")
+    flags+=("--namespace=")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--namespace=")
+    flags+=("--param=")
+    two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--param=")
+    flags+=("--params-json=")
+    local_nonpersistent_flags+=("--params-json=")
+    flags+=("--plan=")
+    local_nonpersistent_flags+=("--plan=")
+    flags+=("--secret=")
+    two_word_flags+=("-s")
+    local_nonpersistent_flags+=("--secret=")
+    flags+=("--timeout=")
+    local_nonpersistent_flags+=("--timeout=")
+    flags+=("--wait")
+    local_nonpersistent_flags+=("--wait")
+    flags+=("--context=")
+    flags+=("--kubeconfig=")
+    flags+=("--logtostderr")
+    flags+=("--v=")
+    two_word_flags+=("-v")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_svcat_set()
+{
+    last_command="svcat_set"
+    commands=()
+    commands+=("instance")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--context=")
+    flags+=("--kubeconfig=")
+    flags+=("--logtostderr")
+    flags+=("--v=")
+    two_word_flags+=("-v")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _svcat_sync_broker()
 {
     last_command="svcat_sync_broker"
@@ -1264,6 +1328,7 @@ _svcat_root_command()
     commands+=("marketplace")
     commands+=("provision")
     commands+=("register")
+    commands+=("set")
     commands+=("sync")
     commands+=("touch")
     commands+=("unbind")

--- a/cmd/svcat/testdata/plugin.yaml
+++ b/cmd/svcat/testdata/plugin.yaml
@@ -383,6 +383,50 @@ tree:
   name: register
   shortDesc: Registers a new broker with service catalog
   use: register NAME --url URL
+- command: ./svcat set
+  name: set
+  shortDesc: Configure a specific resource
+  tree:
+  - command: ./svcat set instance
+    example: |2-
+        svcat set instance wordpress-mysql-instance --plan free
+        svcat set instance wordpress-mysql-instance --plan free -s mysecret[dbparams]
+        svcat set instance secure-instance --plan secureDB --params-json '{
+          "encrypt" : true,
+          "firewallRules" : [
+              {
+                  "name": "AllowSome",
+                  "startIPAddress": "75.70.113.50",
+                  "endIPAddress" : "75.70.113.131"
+              }
+          ]
+        }'
+    flags:
+    - desc: 'Poll interval for --wait, specified in human readable format: 30s, 1m,
+        1h'
+      name: interval
+    - desc: 'Additional parameter to use when updating the service instance, format:
+        NAME=VALUE. Cannot be combined with --params-json, Sensitive information should
+        be placed in a secret and specified with --secret'
+      name: param
+      shorthand: p
+    - desc: Additional parameters to use when updating the service instance, provided
+        as a JSON object. Cannot be combined with --param
+      name: params-json
+    - desc: The plan name (Required)
+      name: plan
+    - desc: 'Additional parameter, whose value is stored in a secret, to use when
+        updating the service instance, format: SECRET[KEY]'
+      name: secret
+    - desc: 'Timeout for --wait, specified in human readable format: 30s, 1m, 1h.
+        Specify -1 to wait indefinitely.'
+      name: timeout
+    - desc: Wait until the operation completes.
+      name: wait
+    name: instance
+    shortDesc: Configure a provisioned service instance
+    use: instance NAME [flags]
+  use: set
 - command: ./svcat sync
   name: sync
   shortDesc: Syncs service catalog for a service broker

--- a/cmd/svcat/testdata/plugin.yaml
+++ b/cmd/svcat/testdata/plugin.yaml
@@ -405,9 +405,9 @@ tree:
     - desc: 'Poll interval for --wait, specified in human readable format: 30s, 1m,
         1h'
       name: interval
-    - desc: 'Additional parameter to use when updating the service instance, format:
-        NAME=VALUE. Cannot be combined with --params-json, Sensitive information should
-        be placed in a secret and specified with --secret'
+    - desc: 'Replaces existing parameters on the service instance, format: NAME=VALUE.
+        Cannot be combined with --params-json, Sensitive information should be placed
+        in a secret and specified with --secret'
       name: param
       shorthand: p
     - desc: Additional parameters to use when updating the service instance, provided

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -301,7 +301,7 @@ TestPollServiceInstanceLastOperationSuccess.
 ### Golden Files
 The svcat tests rely on "[golden files](https://medium.com/@povilasve/go-advanced-tips-tricks-a872503ac859#a196)",
 a pattern used in the Go standard library, for testing command output. The expected
-output is stored in a file in the testdata directory, `cmd/svcat/testdata`, and
+output is stored in a file in the testdata directory, `cmd/svcat/testdata`, 
 and then the test's output is compared against the "golden output" stored
 in that file. It helps avoid putting hard coded strings in the tests themselves.
 

--- a/pkg/svcat/service-catalog/instance.go
+++ b/pkg/svcat/service-catalog/instance.go
@@ -219,31 +219,6 @@ func (sdk *SDK) UpdateInstance(namespace, instanceName, planName string,
 	return result, nil
 }
 
-// TouchInstance increments the updateRequests field on an instance to make
-// service process it again (might be an update, delete, or noop)
-func (sdk *SDK) TouchInstance(ns, name string, retries int) error {
-	for j := 0; j < retries; j++ {
-		inst, err := sdk.RetrieveInstance(ns, name)
-		if err != nil {
-			return err
-		}
-
-		inst.Spec.UpdateRequests = inst.Spec.UpdateRequests + 1
-
-		_, err = sdk.ServiceCatalog().ServiceInstances(ns).Update(inst)
-		if err == nil {
-			return nil
-		}
-		// if we didn't get a conflict, no idea what happened
-		if !apierrors.IsConflict(err) {
-			return fmt.Errorf("could not touch instance (%s)", err)
-		}
-	}
-
-	// conflict after `retries` tries
-	return fmt.Errorf("could not sync service broker after %d tries", retries)
-}
-
 // WaitForInstanceToNotExist waits for the specified instance to no longer exist.
 func (sdk *SDK) WaitForInstanceToNotExist(ns, name string, interval time.Duration, timeout *time.Duration) (instance *v1beta1.ServiceInstance, err error) {
 	if timeout == nil {

--- a/pkg/svcat/service-catalog/instance.go
+++ b/pkg/svcat/service-catalog/instance.go
@@ -219,6 +219,31 @@ func (sdk *SDK) UpdateInstance(namespace, instanceName, planName string,
 	return result, nil
 }
 
+// TouchInstance increments the updateRequests field on an instance to make
+// service process it again (might be an update, delete, or noop)
+func (sdk *SDK) TouchInstance(ns, name string, retries int) error {
+	for j := 0; j < retries; j++ {
+		inst, err := sdk.RetrieveInstance(ns, name)
+		if err != nil {
+			return err
+		}
+
+		inst.Spec.UpdateRequests = inst.Spec.UpdateRequests + 1
+
+		_, err = sdk.ServiceCatalog().ServiceInstances(ns).Update(inst)
+		if err == nil {
+			return nil
+		}
+		// if we didn't get a conflict, no idea what happened
+		if !apierrors.IsConflict(err) {
+			return fmt.Errorf("could not touch instance (%s)", err)
+		}
+	}
+
+	// conflict after `retries` tries
+	return fmt.Errorf("could not sync service broker after %d tries", retries)
+}
+
 // WaitForInstanceToNotExist waits for the specified instance to no longer exist.
 func (sdk *SDK) WaitForInstanceToNotExist(ns, name string, interval time.Duration, timeout *time.Duration) (instance *v1beta1.ServiceInstance, err error) {
 	if timeout == nil {

--- a/pkg/svcat/service-catalog/instance_test.go
+++ b/pkg/svcat/service-catalog/instance_test.go
@@ -239,6 +239,7 @@ var _ = Describe("Instances", func() {
 			secrets["username"] = "admin"
 			secrets["password"] = "abc123"
 			retries := 3
+
 			opts := &ProvisionOptions{
 				ExternalID: "",
 				Namespace:  namespace,
@@ -247,6 +248,7 @@ var _ = Describe("Instances", func() {
 			}
 
 			provisionedInstance, err := sdk.Provision(instanceName, className, planName, opts)
+
 			Expect(err).To(BeNil())
 			// once for the provision request
 			actions := svcCatClient.Actions()

--- a/pkg/svcat/service-catalog/instance_test.go
+++ b/pkg/svcat/service-catalog/instance_test.go
@@ -239,7 +239,6 @@ var _ = Describe("Instances", func() {
 			secrets["username"] = "admin"
 			secrets["password"] = "abc123"
 			retries := 3
-
 			opts := &ProvisionOptions{
 				ExternalID: "",
 				Namespace:  namespace,
@@ -299,8 +298,14 @@ var _ = Describe("Instances", func() {
 			secrets := make(map[string]string)
 			secrets["username"] = "admin"
 			secrets["password"] = "abc123"
+			opts := &ProvisionOptions{
+				ExternalID: externalID,
+				Namespace:  namespace,
+				Params:     params,
+				Secrets:    secrets,
+			}
 
-			_, err := sdk.Provision(namespace, instanceName, externalID, className, planName, params, secrets)
+			_, err := sdk.Provision(instanceName, className, planName, opts)
 			Expect(err).To(BeNil())
 			// once for the provision request
 			actions := svcCatClient.Actions()

--- a/pkg/svcat/service-catalog/parameters.go
+++ b/pkg/svcat/service-catalog/parameters.go
@@ -37,6 +37,8 @@ func BuildParameters(params interface{}) *runtime.RawExtension {
 	return &runtime.RawExtension{Raw: paramsJSON}
 }
 
+// BuildParametersFromInstance unmarshalls a rawExtension retrieved from the ServiceCatalog API,
+// so that it can be used by commands
 func BuildParametersFromInstance(rawExtension *runtime.RawExtension) interface{} {
 	var unmarshaledJSON interface{}
 	raw := rawExtension.Raw
@@ -72,6 +74,8 @@ func BuildParametersFrom(secrets map[string]string) []v1beta1.ParametersFromSour
 	return params
 }
 
+// BuildMapFromInstanceSecretRefs converts secret refs retrieved from the ServiceCatalog API to a map of secrets names to secret keys,
+// so that it can be used by commands
 func BuildMapFromInstanceSecretRefs(params []v1beta1.ParametersFromSource) map[string]string {
 	secrets := make(map[string]string, 0)
 	for _, param := range params {

--- a/pkg/svcat/service-catalog/sdk.go
+++ b/pkg/svcat/service-catalog/sdk.go
@@ -69,7 +69,6 @@ type SvcatClient interface {
 	RetrieveInstances(string, string, string) (*apiv1beta1.ServiceInstanceList, error)
 	RetrieveInstancesByPlan(Plan) ([]apiv1beta1.ServiceInstance, error)
 	UpdateInstance(string, string, string, interface{}, map[string]string) (*apiv1beta1.ServiceInstance, error)
-	TouchInstance(string, string, int) error
 	WaitForInstance(string, string, time.Duration, *time.Duration) (*apiv1beta1.ServiceInstance, error)
 	WaitForInstanceToNotExist(string, string, time.Duration, *time.Duration) (*apiv1beta1.ServiceInstance, error)
 

--- a/pkg/svcat/service-catalog/sdk.go
+++ b/pkg/svcat/service-catalog/sdk.go
@@ -69,6 +69,7 @@ type SvcatClient interface {
 	RetrieveInstances(string, string, string) (*apiv1beta1.ServiceInstanceList, error)
 	RetrieveInstancesByPlan(Plan) ([]apiv1beta1.ServiceInstance, error)
 	UpdateInstance(string, string, string, interface{}, map[string]string) (*apiv1beta1.ServiceInstance, error)
+	TouchInstance(string, string, int) error
 	WaitForInstance(string, string, time.Duration, *time.Duration) (*apiv1beta1.ServiceInstance, error)
 	WaitForInstanceToNotExist(string, string, time.Duration, *time.Duration) (*apiv1beta1.ServiceInstance, error)
 

--- a/pkg/svcat/service-catalog/sdk.go
+++ b/pkg/svcat/service-catalog/sdk.go
@@ -68,6 +68,7 @@ type SvcatClient interface {
 	RetrieveInstanceByBinding(*apiv1beta1.ServiceBinding) (*apiv1beta1.ServiceInstance, error)
 	RetrieveInstances(string, string, string) (*apiv1beta1.ServiceInstanceList, error)
 	RetrieveInstancesByPlan(Plan) ([]apiv1beta1.ServiceInstance, error)
+	UpdateInstance(string, string, string, interface{}, map[string]string) (*apiv1beta1.ServiceInstance, error)
 	TouchInstance(string, string, int) error
 	WaitForInstance(string, string, time.Duration, *time.Duration) (*apiv1beta1.ServiceInstance, error)
 	WaitForInstanceToNotExist(string, string, time.Duration, *time.Duration) (*apiv1beta1.ServiceInstance, error)

--- a/pkg/svcat/service-catalog/service-catalogfakes/fake_svcat_client.go
+++ b/pkg/svcat/service-catalog/service-catalogfakes/fake_svcat_client.go
@@ -482,6 +482,23 @@ type FakeSvcatClient struct {
 		result1 []apiv1beta1.ServiceInstance
 		result2 error
 	}
+	UpdateInstanceStub        func(string, string, string, interface{}, map[string]string) (*apiv1beta1.ServiceInstance, error)
+	updateInstanceMutex       sync.RWMutex
+	updateInstanceArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 interface{}
+		arg5 map[string]string
+	}
+	updateInstanceReturns struct {
+		result1 *apiv1beta1.ServiceInstance
+		result2 error
+	}
+	updateInstanceReturnsOnCall map[int]struct {
+		result1 *apiv1beta1.ServiceInstance
+		result2 error
+	}
 	TouchInstanceStub        func(string, string, int) error
 	touchInstanceMutex       sync.RWMutex
 	touchInstanceArgsForCall []struct {
@@ -2337,6 +2354,61 @@ func (fake *FakeSvcatClient) RetrieveInstancesByPlanReturnsOnCall(i int, result1
 	}{result1, result2}
 }
 
+func (fake *FakeSvcatClient) UpdateInstance(arg1 string, arg2 string, arg3 string, arg4 interface{}, arg5 map[string]string) (*apiv1beta1.ServiceInstance, error) {
+	fake.updateInstanceMutex.Lock()
+	ret, specificReturn := fake.updateInstanceReturnsOnCall[len(fake.updateInstanceArgsForCall)]
+	fake.updateInstanceArgsForCall = append(fake.updateInstanceArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 interface{}
+		arg5 map[string]string
+	}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("UpdateInstance", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.updateInstanceMutex.Unlock()
+	if fake.UpdateInstanceStub != nil {
+		return fake.UpdateInstanceStub(arg1, arg2, arg3, arg4, arg5)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.updateInstanceReturns.result1, fake.updateInstanceReturns.result2
+}
+
+func (fake *FakeSvcatClient) UpdateInstanceCallCount() int {
+	fake.updateInstanceMutex.RLock()
+	defer fake.updateInstanceMutex.RUnlock()
+	return len(fake.updateInstanceArgsForCall)
+}
+
+func (fake *FakeSvcatClient) UpdateInstanceArgsForCall(i int) (string, string, string, interface{}, map[string]string) {
+	fake.updateInstanceMutex.RLock()
+	defer fake.updateInstanceMutex.RUnlock()
+	return fake.updateInstanceArgsForCall[i].arg1, fake.updateInstanceArgsForCall[i].arg2, fake.updateInstanceArgsForCall[i].arg3, fake.updateInstanceArgsForCall[i].arg4, fake.updateInstanceArgsForCall[i].arg5
+}
+
+func (fake *FakeSvcatClient) UpdateInstanceReturns(result1 *apiv1beta1.ServiceInstance, result2 error) {
+	fake.UpdateInstanceStub = nil
+	fake.updateInstanceReturns = struct {
+		result1 *apiv1beta1.ServiceInstance
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSvcatClient) UpdateInstanceReturnsOnCall(i int, result1 *apiv1beta1.ServiceInstance, result2 error) {
+	fake.UpdateInstanceStub = nil
+	if fake.updateInstanceReturnsOnCall == nil {
+		fake.updateInstanceReturnsOnCall = make(map[int]struct {
+			result1 *apiv1beta1.ServiceInstance
+			result2 error
+		})
+	}
+	fake.updateInstanceReturnsOnCall[i] = struct {
+		result1 *apiv1beta1.ServiceInstance
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeSvcatClient) TouchInstance(arg1 string, arg2 string, arg3 int) error {
 	fake.touchInstanceMutex.Lock()
 	ret, specificReturn := fake.touchInstanceReturnsOnCall[len(fake.touchInstanceArgsForCall)]
@@ -2920,6 +2992,8 @@ func (fake *FakeSvcatClient) Invocations() map[string][][]interface{} {
 	defer fake.retrieveInstancesMutex.RUnlock()
 	fake.retrieveInstancesByPlanMutex.RLock()
 	defer fake.retrieveInstancesByPlanMutex.RUnlock()
+	fake.updateInstanceMutex.RLock()
+	defer fake.updateInstanceMutex.RUnlock()
 	fake.touchInstanceMutex.RLock()
 	defer fake.touchInstanceMutex.RUnlock()
 	fake.waitForInstanceMutex.RLock()


### PR DESCRIPTION
# Add support for updating service instances

This pull request adds the ```svcat set instance``` command so that updating an instance's plan and parameters is possible through the Service Catalog CLI.


### Notice:
The change itself sets the foundation for other **set** commands so that other resources could be updated through the *svcat* tool in the future.

### Proposition:
With the new **svcat set instance** command, if you don't update any of the properties of a specific instance, the **UpdateRequests** counter will still get incremented by  one - this is by design. I propose this be the replacement for the **svcat touch** command altogether. It's my belief that it makes more sense to issue a **svcat set instance** command when you want to refresh an instance rather than support a whole different command which sole purpose is to do that. By using the **svcat set instance** command we get more bang for our buck, because we'll have a single command for all our update related needs.

With all that said I propose that we deprecate/remove the **svcat touch** command and all the logic associated with it. The logic for touch is nearly identical to the one for update, so it's only going to be double maintenance if this is not addressed.

### Pull request status:
- [x] Implementation
- [x] Fix old tests
- [x] Write tests for new code

Closes: #2321 