### PR TITLE
Enable client-go's cache mutation detector during tests

### DIFF
--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -4113,6 +4113,6 @@ func assertActionEquals(t *testing.T, action clientgotesting.Action, expectedVer
 
 func reconcileServiceBinding(t *testing.T, testController *controller, binding *v1beta1.ServiceBinding) error {
 	err := testController.reconcileServiceBinding(binding)
-	getMutationDetector().AddObject(binding)
+	mutationDetector(binding)
 	return err
 }

--- a/pkg/controller/controller_binding_test.go
+++ b/pkg/controller/controller_binding_test.go
@@ -4112,10 +4112,7 @@ func assertActionEquals(t *testing.T, action clientgotesting.Action, expectedVer
 }
 
 func reconcileServiceBinding(t *testing.T, testController *controller, binding *v1beta1.ServiceBinding) error {
-	clone := binding.DeepCopy()
 	err := testController.reconcileServiceBinding(binding)
-	if !reflect.DeepEqual(binding, clone) {
-		t.Errorf("reconcileServiceBinding shouldn't mutate input, but it does: %s", expectedGot(clone, binding))
-	}
+	getMutationDetector().AddObject(binding)
 	return err
 }

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -6206,6 +6206,6 @@ func assertServiceInstanceOperationInProgressWithParametersIsTheOnlyCatalogClien
 
 func reconcileServiceInstance(t *testing.T, testController *controller, instance *v1beta1.ServiceInstance) error {
 	err := testController.reconcileServiceInstance(instance)
-	getMutationDetector().AddObject(instance)
+	mutationDetector(instance)
 	return err
 }

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -6205,10 +6205,7 @@ func assertServiceInstanceOperationInProgressWithParametersIsTheOnlyCatalogClien
 }
 
 func reconcileServiceInstance(t *testing.T, testController *controller, instance *v1beta1.ServiceInstance) error {
-	clone := instance.DeepCopy()
 	err := testController.reconcileServiceInstance(instance)
-	if !reflect.DeepEqual(instance, clone) {
-		t.Errorf("reconcileServiceInstance shouldn't mutate input, but it does: %s", expectedGot(clone, instance))
-	}
+	getMutationDetector().AddObject(instance)
 	return err
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apiserver/pkg/server"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	scfeatures "github.com/kubernetes-incubator/service-catalog/pkg/features"
@@ -4007,7 +4008,7 @@ func getMutationDetector() cache.CacheMutationDetector {
 			return detector
 		}
 		detector = cache.NewCacheMutationDetector("controller")
-		ch := make(<-chan struct{})
+		ch := server.SetupSignalHandler()
 		go func() {
 			detector.Run(ch)
 		}()


### PR DESCRIPTION
This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
[Enable the Informer's cacheMutationDetector during tests #2487](https://github.com/kubernetes-incubator/service-catalog/issues/2487)
