### PR TITLE
Make timeout of any request to the broker globally configurable

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -80,6 +80,7 @@ chart and their default values.
 | `controllerManager.healthcheck.enabled` | Enable readiness and liveliness probes | `true` |
 | `controllerManager.verbosity` | Log level; valid values are in the range 0 - 10 | `10` |
 | `controllerManager.resyncInterval` | How often the controller should resync informers; duration format (`20m`, `1h`, etc) | `5m` |
+| `controllerManager.osbApiRequestTimeout` | The maximum amount of timeout to any request to the broker; duration format (`60s`, `3m`, etc) | `60s` |
 | `controllerManager.brokerRelistInterval` | How often the controller should relist the catalogs of ready brokers; duration format (`20m`, `1h`, etc) | `24h` |
 | `controllerManager.brokerRelistIntervalActivated` | Whether or not the controller supports a --broker-relist-interval flag. If this is set to true, brokerRelistInterval will be used as the value for that flag. | `true` |
 | `controllerManager.profiling.disabled` | Disable profiling via web interface host:port/debug/pprof/ | `false` |

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -80,6 +80,10 @@ spec:
         - --operation-polling-maximum-backoff-duration
         - {{ .Values.controllerManager.operationPollingMaximumBackoffDuration }}
         {{- end }}
+        {{ if .Values.controllerManager.osbApiRequestTimeout -}}
+        - --osb-api-request-timeout
+        - {{ .Values.controllerManager.osbApiRequestTimeout }}
+        {{- end }}
         - --feature-gates
         - OriginatingIdentity={{.Values.originatingIdentityEnabled}}
         - --feature-gates

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -149,6 +149,8 @@ controllerManager:
   brokerRelistIntervalActivated: true
    # The maximum amount of time to back-off while polling an OSB API operation; format is a duration (`20m`, `1h`, etc)
   operationPollingMaximumBackoffDuration: 20m
+  # The maximum amount of timeout to any request to the broker; format is a duration (`60s`, `3m`, etc)
+  osbApiRequestTimeout: 60s
   # enables profiling via web interface host:port/debug/pprof/
   profiling:
     # Disable profiling via web interface host:port/debug/pprof/

--- a/cmd/controller-manager/app/controller_manager.go
+++ b/cmd/controller-manager/app/controller_manager.go
@@ -402,6 +402,7 @@ func StartControllers(s *options.ControllerManagerServer,
 		s.OperationPollingMaximumBackoffDuration,
 		s.ClusterIDConfigMapName,
 		s.ClusterIDConfigMapNamespace,
+		s.OSBAPITimeOut,
 	)
 	if err != nil {
 		return err

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -60,6 +60,7 @@ const (
 	defaultLeaderElectionNamespace                = "kube-system"
 	defaultReconciliationRetryDuration            = 7 * 24 * time.Hour
 	defaultOperationPollingMaximumBackoffDuration = 20 * time.Minute
+	defaultOSBAPITimeOut                          = 60 * time.Second
 )
 
 var defaultOSBAPIPreferredVersion = osb.LatestAPIVersion().HeaderValue()
@@ -78,6 +79,7 @@ func NewControllerManagerServer() *ControllerManagerServer {
 			ServiceBrokerRelistInterval:            defaultServiceBrokerRelistInterval,
 			OSBAPIContextProfile:                   defaultOSBAPIContextProfile,
 			OSBAPIPreferredVersion:                 defaultOSBAPIPreferredVersion,
+			OSBAPITimeOut:                          defaultOSBAPITimeOut,
 			ConcurrentSyncs:                        defaultConcurrentSyncs,
 			LeaderElection:                         leaderelectionconfig.DefaultLeaderElectionConfiguration(),
 			LeaderElectionNamespace:                defaultLeaderElectionNamespace,
@@ -119,6 +121,7 @@ func (s *ControllerManagerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.LeaderElectionNamespace, "leader-election-namespace", s.LeaderElectionNamespace, "Namespace to use for leader election lock")
 	fs.DurationVar(&s.ReconciliationRetryDuration, "reconciliation-retry-duration", s.ReconciliationRetryDuration, "The maximum amount of time to retry reconciliations on a resource before failing")
 	fs.DurationVar(&s.OperationPollingMaximumBackoffDuration, "operation-polling-maximum-backoff-duration", s.OperationPollingMaximumBackoffDuration, "The maximum amount of time to back-off while polling an OSB API operation")
+	fs.DurationVar(&s.OSBAPITimeOut, "osb-api-request-timeout", s.OSBAPITimeOut, "The maximum amount of timeout to any request to the broker.")
 	s.SecureServingOptions.AddFlags(fs)
 	utilfeature.DefaultMutableFeatureGate.AddFlag(fs)
 	fs.StringVar(&s.ClusterIDConfigMapName, "cluster-id-configmap-name", controller.DefaultClusterIDConfigMapName, "k8s name for clusterid configmap")

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -77,6 +77,9 @@ type ControllerManagerConfiguration struct {
 	OSBAPIContextProfile   bool
 	OSBAPIPreferredVersion string
 
+	// OSBAPITimeOut the length of the timeout of any request to the broker.
+	OSBAPITimeOut time.Duration
+
 	// ConcurrentSyncs is the number of resources, per resource type,
 	// that are allowed to sync concurrently. Larger number = more responsive
 	// SC operations, but more CPU (and network) load.

--- a/pkg/controller/case_test.go
+++ b/pkg/controller/case_test.go
@@ -131,6 +131,7 @@ func newControllerTest(t *testing.T) *controllerTest {
 		7*24*time.Hour,
 		"DefaultClusterIDConfigMapName",
 		"DefaultClusterIDConfigMapNamespace",
+		60*time.Second,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/controller/controller_clusterservicebroker.go
+++ b/pkg/controller/controller_clusterservicebroker.go
@@ -137,7 +137,7 @@ func (c *controller) clusterServiceBrokerClient(broker *v1beta1.ClusterServiceBr
 		}
 		return nil, err
 	}
-	clientConfig := NewClientConfigurationForBroker(broker.ObjectMeta, &broker.Spec.CommonServiceBrokerSpec, authConfig)
+	clientConfig := NewClientConfigurationForBroker(broker.ObjectMeta, &broker.Spec.CommonServiceBrokerSpec, authConfig, c.OSBAPITimeOut)
 	brokerClient, err := c.brokerClientManager.UpdateBrokerClient(NewClusterServiceBrokerKey(broker.Name), clientConfig)
 	if err != nil {
 		s := fmt.Sprintf("Error creating client for broker %q: %s", broker.Name, err)

--- a/pkg/controller/controller_clusterservicebroker_test.go
+++ b/pkg/controller/controller_clusterservicebroker_test.go
@@ -232,6 +232,21 @@ func TestShouldReconcileClusterServiceBroker(t *testing.T) {
 	}
 }
 
+// TestReconcileClusterServiceBrokerSetOSBTimeOut
+// verifies that timeout of any request to the
+// broker takes effect.
+func TestReconcileClusterServiceBrokerSetOSBTimeOut(t *testing.T) {
+	_, _, _, testController, _ := newTestController(t, getTestCatalogConfig())
+	testController.OSBAPITimeOut = time.Second * 80
+	if err := reconcileClusterServiceBroker(t, testController, getTestClusterServiceBroker()); err != nil {
+		t.Fatalf("This should not fail : %v", err)
+	}
+	createdClient := testController.brokerClientManager.clients[NewClusterServiceBrokerKey(getTestClusterServiceBroker().Name)]
+	if createdClient.clientConfig.TimeoutSeconds != int(testController.OSBAPITimeOut.Seconds()) {
+		t.Errorf("Unexpected OSBTimeOut: got %v, expeted %v", createdClient.clientConfig.TimeoutSeconds, int(testController.OSBAPITimeOut.Seconds()))
+	}
+}
+
 // TestReconcileClusterServiceBrokerExistingServiceClassAndServicePlan
 // verifies a simple, successful run of reconcileClusterServiceBroker() when a
 // ClusterServiceClass and plan already exist.  This test will cause

--- a/pkg/controller/controller_servicebroker.go
+++ b/pkg/controller/controller_servicebroker.go
@@ -127,7 +127,7 @@ func (c *controller) serviceBrokerClient(broker *v1beta1.ServiceBroker) (osb.Cli
 		return nil, err
 	}
 
-	clientConfig := NewClientConfigurationForBroker(broker.ObjectMeta, &broker.Spec.CommonServiceBrokerSpec, authConfig)
+	clientConfig := NewClientConfigurationForBroker(broker.ObjectMeta, &broker.Spec.CommonServiceBrokerSpec, authConfig, c.OSBAPITimeOut)
 
 	brokerClient, err := c.brokerClientManager.UpdateBrokerClient(NewServiceBrokerKey(broker.Namespace, broker.Name), clientConfig)
 	if err != nil {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2354,6 +2354,7 @@ func newTestController(t *testing.T, config fakeosb.FakeClientConfiguration) (
 		7*24*time.Hour,
 		DefaultClusterIDConfigMapName,
 		DefaultClusterIDConfigMapNamespace,
+		60*time.Second,
 	)
 
 	if err != nil {

--- a/test/integration/controller_test.go
+++ b/test/integration/controller_test.go
@@ -791,6 +791,7 @@ func newControllerTestTestController(ct *controllerTest) (
 		7*24*time.Hour,
 		controller.DefaultClusterIDConfigMapName,
 		controller.DefaultClusterIDConfigMapNamespace,
+		60*time.Second,
 	)
 	t.Log("controller start")
 	if err != nil {
@@ -957,6 +958,7 @@ func newTestController(t *testing.T) (
 		7*24*time.Hour,
 		controller.DefaultClusterIDConfigMapName,
 		controller.DefaultClusterIDConfigMapNamespace,
+		60*time.Second,
 	)
 	t.Log("controller start")
 	if err != nil {


### PR DESCRIPTION
We find the delay in creating instance binding varies. The current
default is to wait one minute, otherwise the creation is considered
a failure. So I do this patch to solve this problem. And I think this
delay is configured for different usage scenarios or brokers.
For example, when the maximum response time of my service is 1 minute,
we may set it to be 60, While yours is 3 minutes, and then you should
set it to be 180.

 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-sigs/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-sigs/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
