### PR TITLE
Add controller Service Instance test

### DIFF
--- a/pkg/controller/case_test.go
+++ b/pkg/controller/case_test.go
@@ -1655,7 +1655,6 @@ func (ct *controllerTest) AssertLastBindRequest(t *testing.T, expectedParams map
 	}
 }
 
-// TODO: move to case_test.go
 // CreateServiceInstance creates a ServiceInstance which is used in testing scenarios.
 func (ct *controllerTest) CreateServiceInstanceWithNonbindablePlan() error {
 	_, err := ct.scInterface.ServiceInstances(testNamespace).Create(&v1beta1.ServiceInstance{
@@ -1682,7 +1681,6 @@ func (ct *controllerTest) CreateServiceInstanceWithNonbindablePlan() error {
 	return err
 }
 
-// TODO: move to case_test.go
 // SetOSBProvisionReactionWithHTTPError configures the broker Provision call response as HTTPStatusCodeError
 func (ct *controllerTest) SetOSBProvisionReactionWithHTTPError(code int) {
 	ct.fakeOSBClient.Lock()
@@ -1694,7 +1692,6 @@ func (ct *controllerTest) SetOSBProvisionReactionWithHTTPError(code int) {
 	}
 }
 
-// TODO: move to case_test.go
 func (ct *controllerTest) CreateBindingWithParams(params map[string]interface{}, paramsFrom []v1beta1.ParametersFromSource) error {
 	var parameters *runtime.RawExtension
 	if params != nil {

--- a/pkg/controller/case_test.go
+++ b/pkg/controller/case_test.go
@@ -312,8 +312,6 @@ func (ct *controllerTest) numberOfOSBActionByType(actionType fakeosb.ActionType)
 	return counter
 }
 
-
-
 // SetFirstOSBPollLastOperationReactionsInProgress makes the broker
 // responses inProgress in first numberOfInProgressResponses calls
 func (ct *controllerTest) SetFirstOSBPollLastOperationReactionsInProgress(numberOfInProgressResponses int) {
@@ -571,7 +569,7 @@ func (ct *controllerTest) CreateBinding() error {
 			},
 			ExternalID: testServiceBindingGUID,
 			SecretName: testBindingName, // set by the webhook
-			UserInfo: fixtureUserInfo(),
+			UserInfo:   fixtureUserInfo(),
 		},
 	})
 	return err
@@ -1717,9 +1715,9 @@ func (ct *controllerTest) CreateBindingWithParams(params map[string]interface{},
 			InstanceRef: v1beta1.LocalObjectReference{
 				Name: testServiceInstanceName,
 			},
-			ExternalID: testServiceBindingGUID,
-			SecretName: testBindingName, // set by the webhook
-			Parameters: parameters,
+			ExternalID:     testServiceBindingGUID,
+			SecretName:     testBindingName, // set by the webhook
+			Parameters:     parameters,
 			ParametersFrom: paramsFrom,
 		},
 	})
@@ -1745,8 +1743,8 @@ func (ct *controllerTest) CreateBindingWithTransforms(transforms []v1beta1.Secre
 			InstanceRef: v1beta1.LocalObjectReference{
 				Name: testServiceInstanceName,
 			},
-			ExternalID: testServiceBindingGUID,
-			SecretName: testBindingName, // set by the webhook
+			ExternalID:       testServiceBindingGUID,
+			SecretName:       testBindingName, // set by the webhook
 			SecretTransforms: transforms,
 		},
 	})

--- a/pkg/controller/case_test.go
+++ b/pkg/controller/case_test.go
@@ -22,6 +22,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -30,6 +32,7 @@ import (
 	scinterface "github.com/kubernetes-sigs/service-catalog/pkg/client/clientset_generated/clientset/typed/servicecatalog/v1beta1"
 	scinformers "github.com/kubernetes-sigs/service-catalog/pkg/client/informers_generated/externalversions"
 	"github.com/kubernetes-sigs/service-catalog/pkg/controller"
+	scfeatures "github.com/kubernetes-sigs/service-catalog/pkg/features"
 	"github.com/pmorie/go-open-service-broker-client/v2"
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
 	fakeosb "github.com/pmorie/go-open-service-broker-client/v2/fake"
@@ -41,6 +44,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	k8sinformers "k8s.io/client-go/informers"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
@@ -52,15 +56,23 @@ const (
 	testClusterServiceBrokerName          = "test-clusterservicebroker"
 	testClusterServiceClassName           = "test-clusterserviceclass"
 	testClusterServicePlanName            = "test-clusterserviceplan"
+	testOtherClusterServicePlanName       = "test-otherclusterserviceplan"
 	testServiceInstanceName               = "service-instance"
 	testClassExternalID                   = "clusterserviceclass-12345"
 	testPlanExternalID                    = "34567"
+	testOtherPlanExternalID               = "76543"
 	testNonbindablePlanExternalID         = "nb34567"
 	testNonbindableClusterServicePlanName = "test-nonbindable-plan"
 	testExternalID                        = "9737b6ed-ca95-4439-8219-c53fcad118ab"
 	testBindingName                       = "test-binding"
 	testServiceBindingGUID                = "bguid"
 	authSecretName                        = "basic-secret-name"
+	testUsername                          = "some-user"
+	secretNameWithParameters              = "secret-name"
+	secretKeyWithParameters               = "secret-key"
+	otherSecretNameWithParameters         = "other-secret-name"
+	otherSecretKeyWithParameters          = "other-secret-key"
+	testDashboardURL                      = "http://test-dashboard.example.com"
 
 	pollingInterval = 50 * time.Millisecond
 	pollingTimeout  = 8 * time.Second
@@ -222,6 +234,12 @@ func (ct *controllerTest) EnableAsyncInstanceUpdate() {
 	ct.fakeOSBClient.UpdateInstanceReaction.(*fakeosb.UpdateInstanceReaction).Response.Async = true
 }
 
+// AsyncForInstanceUpdate configures all fake OSB client update
+// responses with async flag
+func (ct *controllerTest) AsyncForInstanceUpdate() {
+	ct.fakeOSBClient.UpdateInstanceReaction.(*fakeosb.UpdateInstanceReaction).Response.Async = true
+}
+
 // EnableAsyncInstanceDeprovisioning configures all fake OSB client deprovision
 // responses with async flag
 func (ct *controllerTest) EnableAsyncInstanceDeprovisioning() {
@@ -270,6 +288,11 @@ func (ct *controllerTest) NumberOfOSBBindingCalls() int {
 // NumberOfOSBProvisionCalls return the total number of OSB provision calls
 func (ct *controllerTest) NumberOfOSBProvisionCalls() int {
 	return ct.numberOfOSBActionByType(fakeosb.ProvisionInstance)
+}
+
+// NumberOfOSBUpdateCalls return the total number of OSB update calls
+func (ct *controllerTest) NumberOfOSBUpdateCalls() int {
+	return ct.numberOfOSBActionByType(fakeosb.UpdateInstance)
 }
 
 // NumberOfOSBDeprovisionCalls returns the total number of OSB deprovision calls
@@ -494,6 +517,7 @@ func (ct *controllerTest) CreateServiceInstance() error {
 			ClusterServiceClassRef: &v1beta1.ClusterObjectReference{
 				Name: testClassExternalID,
 			},
+			UserInfo: fixtureUserInfo(),
 		},
 	})
 	return err
@@ -934,6 +958,670 @@ func (ct *controllerTest) v1Now() *metav1.Time {
 	return &n
 }
 
+// TimeoutError simulates timeout error in provision ServiceInstance test
+type TimeoutError string
+
+// Timeout method require for TimeoutError type to meet the url/timeout interface
+func (e TimeoutError) Timeout() bool {
+	return true
+}
+
+// Error returns the TimeoutError as a string
+func (e TimeoutError) Error() string {
+	return string(e)
+}
+
+// SetupEmptyPlanListForOSBClient sets up fake OSB client response to return plans which not exist in any ServiceInstance
+func (ct *controllerTest) SetupEmptyPlanListForOSBClient() {
+	ct.fakeOSBClient.CatalogReaction.(*fakeosb.CatalogReaction).Response = &osb.CatalogResponse{
+		Services: []osb.Service{
+			{
+				Name:        testClusterServiceClassName,
+				ID:          testClassExternalID,
+				Description: "a test service",
+				Bindable:    true,
+				Plans: []osb.Plan{
+					{
+						Name:        "randomPlan",
+						Free:        truePtr(),
+						ID:          "randomID",
+						Description: "This is plan which should not exist in any of instance",
+					},
+				},
+			},
+		},
+	}
+}
+
+// WaitForInstanceCondition waits until ServiceInstance `status.conditions` field value is equal to condition in parameters
+// returns error if the time limit has been reached
+func (ct *controllerTest) WaitForInstanceCondition(condition v1beta1.ServiceInstanceCondition) error {
+	var lastInstance *v1beta1.ServiceInstance
+	err := wait.PollImmediate(pollingInterval, pollingTimeout, func() (bool, error) {
+		instance, err := ct.scInterface.ServiceInstances(testNamespace).Get(testServiceInstanceName, v1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("error getting Instance: %v", err)
+		}
+
+		for _, cond := range instance.Status.Conditions {
+			if condition.Type == cond.Type && condition.Status == cond.Status && condition.Reason == cond.Reason {
+				return true, nil
+			}
+		}
+		lastInstance = instance
+		return false, nil
+	})
+	if err == wait.ErrWaitTimeout {
+		return fmt.Errorf(
+			"instance with proper conditions not found, the existing conditions: %+v", lastInstance.Status.Conditions)
+	}
+	return err
+}
+
+// WaitForServiceInstanceProcessedGeneration waits until ServiceInstance parameter `Status.ObservedGeneration` is
+// equal or higher than ServiceInstance `generation` value, ServiceInstance is in Ready/True status and
+// ServiceInstance is not in Orphan Mitigation progress
+func (ct *controllerTest) WaitForServiceInstanceProcessedGeneration(generation int64) error {
+	err := wait.PollImmediate(pollingInterval, pollingTimeout, func() (bool, error) {
+		instance, err := ct.scInterface.ServiceInstances(testNamespace).Get(testServiceInstanceName, v1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("error getting Instance: %v", err)
+		}
+
+		if instance.Status.ObservedGeneration >= generation &&
+			isServiceInstanceConditionTrue(instance) &&
+			!instance.Status.OrphanMitigationInProgress {
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	if err == wait.ErrWaitTimeout {
+		return fmt.Errorf(
+			"instance with proper ProcessedGeneration status not found")
+	}
+	return err
+}
+
+func isServiceInstanceConditionTrue(instance *v1beta1.ServiceInstance) bool {
+	for _, cond := range instance.Status.Conditions {
+		if cond.Type == v1beta1.ServiceInstanceConditionReady || cond.Type == v1beta1.ServiceInstanceConditionFailed {
+			return cond.Status == v1beta1.ConditionTrue
+		}
+	}
+
+	return false
+}
+
+// AssertServiceInstanceHasNoCondition makes sure ServiceInstance is in not specific condition
+func (ct *controllerTest) AssertServiceInstanceHasNoCondition(t *testing.T, cond v1beta1.ServiceInstanceCondition) {
+	instance, err := ct.scInterface.ServiceInstances(testNamespace).Get(testServiceInstanceName, v1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting Instance: %v", err)
+	}
+
+	for _, condition := range instance.Status.Conditions {
+		if t1, t2 := condition.Type, cond.Type; t1 == t2 {
+			if s1, s2 := condition.Status, cond.Status; s1 == s2 {
+				t.Fatalf(
+					"unexpected condition status: expected %v, got %v or \n "+
+						"unexpected condition type: expected %v, got %v", s2, s1, t2, t1)
+			}
+		}
+	}
+}
+
+// AssertServiceInstanceOrphanMitigationStatus makes sure ServiceInstance is/or is not in Orphan Mitigation progress
+func (ct *controllerTest) AssertServiceInstanceOrphanMitigationStatus(t *testing.T, state bool) {
+	instance, err := ct.scInterface.ServiceInstances(testNamespace).Get(testServiceInstanceName, v1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting Instance: %v", err)
+	}
+
+	if om := instance.Status.OrphanMitigationInProgress; om != state {
+		t.Fatalf("unexpected OrphanMitigationInProgress status: expected %v, got %v", state, om)
+	}
+}
+
+// CreateClusterServiceClass creates ClusterServiceClass with default parameters
+func (ct *controllerTest) CreateClusterServiceClass() error {
+	serviceClass := &v1beta1.ClusterServiceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testClassExternalID,
+		},
+		Spec: v1beta1.ClusterServiceClassSpec{
+			ClusterServiceBrokerName: testClusterServiceBrokerName,
+			CommonServiceClassSpec: v1beta1.CommonServiceClassSpec{
+				ExternalID:   testClassExternalID,
+				ExternalName: testClusterServiceClassName,
+				Description:  "a test service",
+				Bindable:     true,
+			},
+		},
+	}
+	if _, err := ct.scInterface.ClusterServiceClasses().Create(serviceClass); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateClusterServicePlan creates CreateClusterServicePlan with default parameters
+func (ct *controllerTest) CreateClusterServicePlan() error {
+	servicePlan := &v1beta1.ClusterServicePlan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testPlanExternalID,
+		},
+		Spec: v1beta1.ClusterServicePlanSpec{
+			ClusterServiceBrokerName: testClusterServicePlanName,
+		},
+	}
+	if _, err := ct.scInterface.ClusterServicePlans().Create(servicePlan); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateServiceInstanceExternalPlanName updates ServiceInstance plan by plan ID
+func (ct *controllerTest) UpdateServiceInstanceExternalPlanName(planID string) (int64, error) {
+	instance, err := ct.scInterface.ServiceInstances(testNamespace).Get(testServiceInstanceName, v1.GetOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("error getting Instance: %v", err)
+	}
+
+	instance.Spec.ClusterServicePlanExternalName = planID
+	instance.Spec.ClusterServicePlanRef = &v1beta1.ClusterObjectReference{
+		Name: planID,
+	}
+
+	instance.Generation = instance.Generation + 1
+	updatedInstance, err := ct.scInterface.ServiceInstances(testNamespace).Update(instance)
+
+	if err != nil {
+		return 0, fmt.Errorf("error updating Instance: %v", err)
+	}
+
+	return updatedInstance.Generation, nil
+}
+
+// UpdateServiceInstanceInternalPlanName updates ServiceInstance plan by plan name
+// CAUTION: because Plan refs are added by a Webhook tests require adds planRef before update ServiceInstance
+func (ct *controllerTest) UpdateServiceInstanceInternalPlanName(planName string) (int64, error) {
+	instance, err := ct.scInterface.ServiceInstances(testNamespace).Get(testServiceInstanceName, v1.GetOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("error getting Instance: %v", err)
+	}
+
+	instance.Spec.ClusterServicePlanName = planName
+	instance.Spec.ClusterServicePlanRef = &v1beta1.ClusterObjectReference{
+		Name: testOtherPlanExternalID,
+	}
+
+	instance.Generation = instance.Generation + 1
+	updatedInstance, err := ct.scInterface.ServiceInstances(testNamespace).Update(instance)
+
+	if err != nil {
+		return 0, fmt.Errorf("error updating Instance: %v", err)
+	}
+
+	return updatedInstance.Generation, nil
+}
+
+// CreateServiceInstanceWithCustomParameters creates ServiceInstance with parameters from map or
+// by adding reference to Secret. If parameters are empty method creates ServiceInstance without parameters
+func (ct *controllerTest) CreateServiceInstanceWithCustomParameters(withParam, paramFromSecret bool) error {
+	var params map[string]interface{}
+	var paramsFrom []v1beta1.ParametersFromSource
+
+	if withParam {
+		params = map[string]interface{}{
+			"param-key": "param-value",
+		}
+	}
+
+	if paramFromSecret {
+		paramsFrom = []v1beta1.ParametersFromSource{
+			{
+				SecretKeyRef: &v1beta1.SecretKeyReference{
+					Name: secretNameWithParameters,
+					Key:  secretKeyWithParameters,
+				},
+			},
+		}
+	}
+
+	var err error
+	if withParam || paramFromSecret {
+		_, err = ct.CreateServiceInstanceWithParameters(params, paramsFrom)
+	} else {
+		err = ct.CreateServiceInstance()
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateServiceInstanceWithParameters creates ServiceInstance with parameters from map and by adding
+// Secret reference
+func (ct *controllerTest) CreateServiceInstanceWithParameters(
+	params map[string]interface{},
+	paramsFrom []v1beta1.ParametersFromSource) (*v1beta1.ServiceInstance, error) {
+	rawParams, err := convertParametersIntoRawExtension(params)
+	if err != nil {
+		return nil, err
+	}
+
+	instance := &v1beta1.ServiceInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testServiceInstanceName,
+			Finalizers: []string{v1beta1.FinalizerServiceCatalog},
+		},
+		Spec: v1beta1.ServiceInstanceSpec{
+			PlanReference: v1beta1.PlanReference{
+				ClusterServiceClassExternalName: testClusterServiceClassName,
+				ClusterServicePlanExternalName:  testClusterServicePlanName,
+			},
+			ClusterServicePlanRef: &v1beta1.ClusterObjectReference{
+				Name: testPlanExternalID,
+			},
+			ClusterServiceClassRef: &v1beta1.ClusterObjectReference{
+				Name: testClassExternalID,
+			},
+			ExternalID:     testExternalID,
+			Parameters:     rawParams,
+			ParametersFrom: paramsFrom,
+		},
+	}
+
+	_, err = ct.scInterface.ServiceInstances(testNamespace).Create(instance)
+	if err != nil {
+		return nil, err
+	}
+
+	return instance, err
+}
+
+// UpdateCustomServiceInstanceParameters updates ServiceInstance with specific parameters. Method updates
+// directly parameters, parameters by adding Secret reference, removes parameters or removes reference to Secret
+func (ct *controllerTest) UpdateCustomServiceInstanceParameters(
+	update, updateFromSecret, delete, deleteFromSecret bool) (int64, error) {
+	instance, err := ct.scInterface.ServiceInstances(testNamespace).Get(testServiceInstanceName, v1.GetOptions{})
+	if err != nil {
+		return 0, err
+	}
+
+	if update {
+		instanceParam, err := convertParametersIntoRawExtension(map[string]interface{}{"param-key": "new-param-value"})
+		if err != nil {
+			return 0, err
+		}
+		instance.Spec.Parameters = instanceParam
+	}
+
+	if delete {
+		instance.Spec.Parameters = nil
+	}
+
+	if updateFromSecret {
+		instance.Spec.ParametersFrom = []v1beta1.ParametersFromSource{
+			{
+				SecretKeyRef: &v1beta1.SecretKeyReference{
+					Name: otherSecretNameWithParameters,
+					Key:  otherSecretKeyWithParameters,
+				},
+			},
+		}
+	}
+
+	if deleteFromSecret {
+		instance.Spec.ParametersFrom = nil
+	}
+
+	instance.Generation = instance.Generation + 1
+	updatedInstance, err := ct.scInterface.ServiceInstances(testNamespace).Update(instance)
+	if err != nil {
+		return 0, err
+	}
+
+	return updatedInstance.Generation, nil
+}
+
+func convertParametersIntoRawExtension(parameters map[string]interface{}) (*runtime.RawExtension, error) {
+	marshalledParams, err := json.Marshal(parameters)
+	if err != nil {
+		return nil, err
+	}
+	return &runtime.RawExtension{Raw: marshalledParams}, nil
+}
+
+// CreateServiceInstanceWithInvalidParameters creates instance and updates parameters with incorrect parameters
+func (ct *controllerTest) CreateServiceInstanceWithInvalidParameters() error {
+	params := map[string]interface{}{
+		"Name": "test-param",
+		"Args": map[string]interface{}{
+			"first":  "first-arg",
+			"second": "second-arg",
+		},
+	}
+	instance, err := ct.CreateServiceInstanceWithParameters(params, nil)
+	if err != nil {
+		return err
+	}
+
+	instance.Spec.Parameters.Raw[0] = 0x21
+	instance.Generation = instance.Generation + 1
+
+	_, err = ct.scInterface.ServiceInstances(testNamespace).Update(instance)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AssertObservedGenerationIsCorrect makes sure ServiceInstance status `ObservedGeneration` parameter is not
+// equal to ServiceInstance `Generation` parameter
+func (ct *controllerTest) AssertObservedGenerationIsCorrect(t *testing.T) {
+	instance, err := ct.scInterface.ServiceInstances(testNamespace).Get(testServiceInstanceName, v1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if g, og := instance.Generation, instance.Status.ObservedGeneration; g != og {
+		t.Fatalf("latest generation not observed: generation: %v, observed: %v", g, og)
+	}
+}
+
+// WaitForReadyUpdateInstance waits for ServiceInstance when Generation parameter will be equal to
+// ObservedGeneration status parameter
+func (ct *controllerTest) WaitForReadyUpdateInstance() error {
+	err := wait.PollImmediate(pollingInterval, pollingTimeout, func() (bool, error) {
+		instance, err := ct.scInterface.ServiceInstances(testNamespace).Get(testServiceInstanceName, v1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("error getting Instance: %v", err)
+		}
+
+		if g, og := instance.Generation, instance.Status.ObservedGeneration; g != og {
+			return true, nil
+		}
+
+		return false, nil
+	})
+	if err == wait.ErrWaitTimeout {
+		return fmt.Errorf("ServiceInstance ObservedGeneration status parameter is out of date")
+	}
+	return err
+}
+
+// SetErrorReactionForProvisioningToOSBClient sets up DynamicProvisionReaction for fake osb client with specific
+// error status code
+func (ct *controllerTest) SetErrorReactionForProvisioningToOSBClient(statusCode int) {
+	ct.fakeOSBClient.Lock()
+	defer ct.fakeOSBClient.Unlock()
+
+	ct.fakeOSBClient.ProvisionReaction = fakeosb.DynamicProvisionReaction(
+		func(_ *osb.ProvisionRequest) (*osb.ProvisionResponse, error) {
+			return nil, osb.HTTPStatusCodeError{
+				StatusCode:   statusCode,
+				ErrorMessage: strPtr("error message"),
+				Description:  strPtr("response description"),
+			}
+		})
+}
+
+// SetCustomErrorReactionForProvisioningToOSBClient sets up DynamicProvisionReaction for fake osb client
+// with specific response
+func (ct *controllerTest) SetCustomErrorReactionForProvisioningToOSBClient(response error) {
+	ct.fakeOSBClient.Lock()
+	defer ct.fakeOSBClient.Unlock()
+
+	ct.fakeOSBClient.ProvisionReaction = fakeosb.DynamicProvisionReaction(
+		func(_ *osb.ProvisionRequest) (*osb.ProvisionResponse, error) {
+			return nil, response
+		})
+}
+
+// SetErrorReactionForDeprovisioningToOSBClient sets up DynamicDeprovisionReaction for fake osb client with specific
+// error status code. Method allows blocking deprovision response
+func (ct *controllerTest) SetErrorReactionForDeprovisioningToOSBClient(statusCode int, block <-chan bool) {
+	ct.fakeOSBClient.Lock()
+	defer ct.fakeOSBClient.Unlock()
+
+	blockDeprovision := true
+	ct.fakeOSBClient.DeprovisionReaction = fakeosb.DynamicDeprovisionReaction(
+		func(_ *osb.DeprovisionRequest) (*osb.DeprovisionResponse, error) {
+			for blockDeprovision {
+				blockDeprovision = <-block
+			}
+			return nil, osb.HTTPStatusCodeError{
+				StatusCode:   statusCode,
+				ErrorMessage: strPtr("temporary deprovision error"),
+			}
+		})
+}
+
+// SetSuccessfullyReactionForProvisioningToOSBClient sets up DynamicProvisionReaction for fake osb client
+// with success response
+func (ct *controllerTest) SetSuccessfullyReactionForProvisioningToOSBClient() {
+	ct.fakeOSBClient.Lock()
+	defer ct.fakeOSBClient.Unlock()
+
+	ct.fakeOSBClient.ProvisionReaction = fakeosb.DynamicProvisionReaction(
+		func(_ *osb.ProvisionRequest) (*osb.ProvisionResponse, error) {
+			return &osb.ProvisionResponse{}, nil
+		})
+}
+
+// SetSuccessfullyReactionForDeprovisioningToOSBClient sets up DynamicDeprovisionReaction for fake osb client
+// with success response
+func (ct *controllerTest) SetSuccessfullyReactionForDeprovisioningToOSBClient() {
+	ct.fakeOSBClient.Lock()
+	defer ct.fakeOSBClient.Unlock()
+
+	ct.fakeOSBClient.DeprovisionReaction = fakeosb.DynamicDeprovisionReaction(
+		func(_ *osb.DeprovisionRequest) (*osb.DeprovisionResponse, error) {
+			return &osb.DeprovisionResponse{}, nil
+		})
+}
+
+// AssertLastOSBUpdatePlanID makes sure osb client action with type "UpdateInstance"
+// contains specific plan ID in request body parameters
+func (ct *controllerTest) AssertLastOSBUpdatePlanID(t *testing.T) {
+	for _, planID := range ct.fetchAllPlansFromUpdateActions() {
+		if planID == testOtherPlanExternalID {
+			return
+		}
+	}
+
+	t.Fatalf("expected ServicePlan %q not exist", testOtherPlanExternalID)
+}
+
+func (ct *controllerTest) fetchAllPlansFromUpdateActions() []string {
+	var plans []string
+	actions := ct.fakeOSBClient.Actions()
+	for _, action := range actions {
+		if action.Type == fakeosb.UpdateInstance {
+			request := action.Request.(*osb.UpdateInstanceRequest)
+			if request.PlanID == nil {
+				continue
+			}
+
+			plans = append(plans, *request.PlanID)
+		}
+	}
+
+	return plans
+}
+
+// AssertBrokerActionWithParametersExist makes sure osb client action with type "UpdateInstance"
+// contains specific parameters in request body parameters
+func (ct *controllerTest) AssertBrokerUpdateActionWithParametersExist(t *testing.T, parameters map[string]interface{}) {
+	actions := ct.fakeOSBClient.Actions()
+	for _, action := range actions {
+		if action.Type != fakeosb.UpdateInstance {
+			continue
+		}
+
+		request := action.Request.(*osb.UpdateInstanceRequest)
+		if !reflect.DeepEqual(request.Parameters, parameters) {
+			t.Fatalf("unexpected parameters: expected %v, got %v", parameters, request.Parameters)
+		}
+	}
+}
+
+// CreateSecretsForServiceInstanceWithSecretParams creates Secrets with specific parameters
+func (ct *controllerTest) CreateSecretsForServiceInstanceWithSecretParams() error {
+	_, err := ct.k8sClient.CoreV1().Secrets(testNamespace).Create(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      secretNameWithParameters,
+		},
+		Data: map[string][]byte{
+			secretKeyWithParameters: []byte(`{"secret-param-key":"secret-param-value"}`),
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = ct.k8sClient.CoreV1().Secrets(testNamespace).Create(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      otherSecretNameWithParameters,
+		},
+		Data: map[string][]byte{
+			otherSecretKeyWithParameters: []byte(`{"other-secret-param-key":"other-secret-param-value"}`),
+		},
+	})
+
+	return err
+}
+
+// SetSimpleErrorUpdateInstanceReaction sets up DynamicUpdateInstanceReaction for fake osb client
+// which returns simple error response during three first call and success response after them
+func (ct *controllerTest) SetSimpleErrorUpdateInstanceReaction() {
+	ct.fakeOSBClient.Lock()
+	defer ct.fakeOSBClient.Unlock()
+
+	numberOfPolls := 0
+	numberOfInProgressResponses := 2
+
+	ct.fakeOSBClient.UpdateInstanceReaction = fakeosb.DynamicUpdateInstanceReaction(
+		func(_ *osb.UpdateInstanceRequest) (*osb.UpdateInstanceResponse, error) {
+			numberOfPolls++
+			if numberOfPolls > numberOfInProgressResponses {
+				return &osb.UpdateInstanceResponse{}, nil
+			}
+			return nil, errors.New("fake update error")
+		})
+}
+
+// SetErrorUpdateInstanceReaction sets up DynamicUpdateInstanceReaction for fake osb client
+// which returns specific error response during three first call and success response after them
+func (ct *controllerTest) SetErrorUpdateInstanceReaction() {
+	ct.fakeOSBClient.Lock()
+	defer ct.fakeOSBClient.Unlock()
+
+	numberOfPolls := 0
+	numberOfInProgressResponses := 2
+
+	ct.fakeOSBClient.UpdateInstanceReaction = fakeosb.DynamicUpdateInstanceReaction(
+		func(_ *osb.UpdateInstanceRequest) (*osb.UpdateInstanceResponse, error) {
+			numberOfPolls++
+			if numberOfPolls > numberOfInProgressResponses {
+				return &osb.UpdateInstanceResponse{}, nil
+			}
+			return nil, osb.HTTPStatusCodeError{
+				StatusCode:   http.StatusConflict,
+				ErrorMessage: strPtr("OutOfQuota"),
+				Description:  strPtr("You're out of quota!"),
+			}
+		})
+}
+
+// SetUpdateServiceInstanceResponseWithDashboardURL sets up UpdateInstanceReaction for fake osb client
+// with specific url under the parameter `DashboardURL`
+func (ct *controllerTest) SetUpdateServiceInstanceResponseWithDashboardURL() {
+	dashURL := testDashboardURL
+	ct.fakeOSBClient.UpdateInstanceReaction = &fakeosb.UpdateInstanceReaction{
+		Response: &osb.UpdateInstanceResponse{
+			DashboardURL: &dashURL,
+		},
+	}
+}
+
+// AssertServiceInstanceDashboardURL makes sure ServiceInstance `Status.DashboardURL` parameter is equal to test URL
+func (ct *controllerTest) AssertServiceInstanceDashboardURL(t *testing.T) {
+	instance, err := ct.scInterface.ServiceInstances(testNamespace).Get(testServiceInstanceName, v1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting Instance: %v", err)
+	}
+
+	dashURL := testDashboardURL
+	return
+	if *instance.Status.DashboardURL != dashURL {
+		t.Fatalf("unexpected DashboardURL: %v expected %v", instance.Status.DashboardURL, dashURL)
+	}
+}
+
+// AssertServiceInstanceEmptyDashboardURL makes sure ServiceInstance `Status.DashboardURL` is empty
+func (ct *controllerTest) AssertServiceInstanceEmptyDashboardURL(t *testing.T) {
+	instance, err := ct.scInterface.ServiceInstances(testNamespace).Get(testServiceInstanceName, v1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting Instance: %v", err)
+	}
+	if instance.Status.DashboardURL != nil {
+		t.Fatalf("Dashboard URL should be nil")
+	}
+}
+
+// SetupFeatureGateDashboardURL sets FeatureGate behavior
+func (ct *controllerTest) SetFeatureGateDashboardURL(enable bool) error {
+	var format string
+	if enable {
+		format = "%v=true"
+	} else {
+		format = "%v=false"
+	}
+
+	parameter := fmt.Sprintf(format, scfeatures.UpdateDashboardURL)
+	if err := utilfeature.DefaultMutableFeatureGate.Set(parameter); err != nil {
+		return fmt.Errorf("Failed to enable updatable dashboard url feature: %v", err)
+	}
+
+	return nil
+}
+
+// CreateSecret creates a secret with given name and stored data
+func (ct *controllerTest) CreateSecret(name string, data map[string][]byte) error {
+	_, err := ct.k8sClient.CoreV1().Secrets(testNamespace).Create(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      name,
+		},
+		Data: data,
+	})
+	return err
+}
+
+// AssertLastBindRequest makes sure parameters are equal to parameters from last binding request
+func (ct *controllerTest) AssertLastBindRequest(t *testing.T, expectedParams map[string]interface{}) {
+	actions := ct.fakeOSBClient.Actions()
+	for i := len(actions) - 1; i >= 0; i-- {
+		action := actions[i]
+		if action.Type == fakeosb.Bind {
+			bindReq := action.Request.(*osb.BindRequest)
+			assert.Equal(t, expectedParams, bindReq.Parameters)
+			return
+		}
+	}
+}
+
 // fixtureHappyPathBrokerClientConfig returns fake configuration for OSB client used in testing scenario
 func fixtureHappyPathBrokerClientConfig() fakeosb.FakeClientConfiguration {
 	return fakeosb.FakeClientConfiguration{
@@ -980,10 +1668,11 @@ func fixtureCatalogResponse() *osb.CatalogResponse {
 	return &osb.CatalogResponse{
 		Services: []osb.Service{
 			{
-				Name:        testClusterServiceClassName,
-				ID:          testClassExternalID,
-				Description: "a test service",
-				Bindable:    true,
+				Name:          testClusterServiceClassName,
+				ID:            testClassExternalID,
+				Description:   "a test service",
+				Bindable:      true,
+				PlanUpdatable: truePtr(),
 				Plans: []osb.Plan{
 					{
 						Name:        testClusterServicePlanName,
@@ -997,6 +1686,12 @@ func fixtureCatalogResponse() *osb.CatalogResponse {
 						ID:          testNonbindablePlanExternalID,
 						Description: "an non-bindable test plan",
 						Bindable:    falsePtr(),
+					},
+					{
+						Name:        testOtherClusterServicePlanName,
+						Free:        truePtr(),
+						ID:          testOtherPlanExternalID,
+						Description: "an other test plan",
 					},
 				},
 			},
@@ -1013,6 +1708,12 @@ func fixtureBindCredentials() map[string]interface{} {
 	}
 }
 
+func fixtureUserInfo() *v1beta1.UserInfo {
+	return &v1beta1.UserInfo{
+		Username: testUsername,
+	}
+}
+
 func truePtr() *bool {
 	b := true
 	return &b
@@ -1021,4 +1722,8 @@ func truePtr() *bool {
 func falsePtr() *bool {
 	b := false
 	return &b
+}
+
+func strPtr(s string) *string {
+	return &s
 }

--- a/pkg/controller/controller_flow_binding_test.go
+++ b/pkg/controller/controller_flow_binding_test.go
@@ -628,6 +628,3 @@ func TestCreateServiceBindingWithSecretTransform(t *testing.T) {
 		})
 	}
 }
-
-
-

--- a/pkg/controller/controller_flow_instance_test.go
+++ b/pkg/controller/controller_flow_instance_test.go
@@ -770,6 +770,7 @@ func TestUpdateServiceInstanceNewDashboardResponse(t *testing.T) {
 			// default value for defaultFuture is false
 			// see https://github.com/kubernetes/apiserver/blob/release-1.14/pkg/util/feature/feature_gate.go
 			defer require.NoError(t, ct.SetFeatureGateDashboardURL(false))
+
 			require.NoError(t, ct.CreateSimpleClusterServiceBroker())
 			require.NoError(t, ct.CreateServiceInstance())
 			require.NoError(t, ct.WaitForReadyInstance())

--- a/pkg/controller/controller_flow_instance_test.go
+++ b/pkg/controller/controller_flow_instance_test.go
@@ -19,7 +19,9 @@ limitations under the License.
 package controller_test
 
 import (
+	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
@@ -159,6 +161,758 @@ func TestServiceInstanceDeleteWithAsyncUpdateInProgress(t *testing.T) {
 			assert.NoError(t, ct.WaitForDeprovisionStatus(v1beta1.ServiceInstanceDeprovisionStatusSucceeded))
 			// at least one deprovisioning call
 			assert.NotZero(t, ct.NumberOfOSBDeprovisionCalls())
+		})
+	}
+}
+
+// TestCreateServiceInstanceFailsWithNonexistentPlan tests creating a ServiceInstance whose ServicePlan
+// does not exist
+func TestCreateServiceInstanceFailsWithNonexistentPlan(t *testing.T) {
+	// GIVEN
+	ct := newControllerTest(t)
+	defer ct.TearDown()
+
+	ct.SetupEmptyPlanListForOSBClient()
+	require.NoError(t, ct.CreateSimpleClusterServiceBroker())
+	require.NoError(t, ct.WaitForReadyBroker())
+
+	// WHEN
+	require.NoError(t, ct.CreateServiceInstance())
+
+	// THEN
+	condition := v1beta1.ServiceInstanceCondition{
+		Type:   v1beta1.ServiceInstanceConditionReady,
+		Status: v1beta1.ConditionFalse,
+		Reason: "ReferencesNonexistentServicePlan",
+	}
+	require.NoError(t, ct.WaitForInstanceCondition(condition))
+}
+
+// TestCreateServiceInstanceNonExistentClusterServiceBroker tests creating a
+// ServiceInstance whose broker does not exist.
+func TestCreateServiceInstanceNonExistentClusterServiceBroker(t *testing.T) {
+	// GIVEN
+	ct := newControllerTest(t)
+	defer ct.TearDown()
+
+	require.NoError(t, ct.CreateClusterServiceClass())
+	require.NoError(t, ct.WaitForClusterServiceClass())
+
+	require.NoError(t, ct.CreateClusterServicePlan())
+	require.NoError(t, ct.WaitForClusterServicePlan())
+
+	// WHEN
+	require.NoError(t, ct.CreateServiceInstance())
+
+	// THEN
+	condition := v1beta1.ServiceInstanceCondition{
+		Type:   v1beta1.ServiceInstanceConditionReady,
+		Status: v1beta1.ConditionFalse,
+		Reason: "ReferencesNonexistentBroker",
+	}
+	require.NoError(t, ct.WaitForInstanceCondition(condition))
+}
+
+// TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan tests that a ServiceInstance gets
+// a Failed condition when the service class or service plan it references does not exist.
+func TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan(t *testing.T) {
+	// TODO: cannot rewrite tests because fakeClient does not support `FieldSelector` during filtering ServiceInstance list
+}
+
+// TestCreateServiceInstanceWithInvalidParameters tests creating a ServiceInstance
+// with invalid parameters.
+func TestCreateServiceInstanceWithInvalidParameters(t *testing.T) {
+	// GIVEN
+	ct := newControllerTest(t)
+	defer ct.TearDown()
+
+	require.NoError(t, ct.CreateSimpleClusterServiceBroker())
+	require.NoError(t, ct.WaitForReadyBroker())
+
+	// WHEN
+	require.NoError(t, ct.CreateServiceInstanceWithInvalidParameters())
+
+	// THEN
+	condition := v1beta1.ServiceInstanceCondition{
+		Type:   v1beta1.ServiceInstanceConditionReady,
+		Status: v1beta1.ConditionFalse,
+		Reason: "ErrorWithParameters",
+	}
+	require.NoError(t, ct.WaitForInstanceCondition(condition))
+}
+
+// TestCreateServiceInstanceWithParameters tests creating a ServiceInstance
+// with parameters.
+func TestCreateServiceInstanceWithParameters(t *testing.T) {
+	type secretDef struct {
+		name string
+		data map[string][]byte
+	}
+
+	for tn, state := range map[string]struct {
+		params                  map[string]interface{}
+		expectedParams          map[string]interface{}
+		paramsFrom              []v1beta1.ParametersFromSource
+		secret                  secretDef
+		expectedConditionStatus v1beta1.ConditionStatus
+		expectedConditionReason string
+	}{
+		"no params": {
+			params:                  nil,
+			expectedParams:          nil,
+			expectedConditionStatus: v1beta1.ConditionTrue,
+			expectedConditionReason: "ProvisionedSuccessfully",
+		},
+		"plain params": {
+			params: map[string]interface{}{
+				"Name": "test-param",
+				"Args": map[string]interface{}{
+					"first":  "first-arg",
+					"second": "second-arg",
+				},
+			},
+			expectedParams: map[string]interface{}{
+				"Name": "test-param",
+				"Args": map[string]interface{}{
+					"first":  "first-arg",
+					"second": "second-arg",
+				},
+			},
+			expectedConditionStatus: v1beta1.ConditionTrue,
+			expectedConditionReason: "ProvisionedSuccessfully",
+		},
+		"secret params": {
+			expectedParams: map[string]interface{}{
+				"A": "B",
+				"C": map[string]interface{}{
+					"D": "E",
+					"F": "G",
+				},
+			},
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secret: secretDef{
+				name: "secret-name",
+				data: map[string][]byte{
+					"secret-key": []byte(`{"A":"B","C":{"D":"E","F":"G"}}`),
+				},
+			},
+			expectedConditionStatus: v1beta1.ConditionTrue,
+			expectedConditionReason: "ProvisionedSuccessfully",
+		},
+		"plain and secret params": {
+			params: map[string]interface{}{
+				"Name": "test-param",
+				"Args": map[string]interface{}{
+					"first":  "first-arg",
+					"second": "second-arg",
+				},
+			},
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secret: secretDef{
+				name: "secret-name",
+				data: map[string][]byte{
+					"secret-key": []byte(`{"A":"B","C":{"D":"E","F":"G"}}`),
+				},
+			},
+			expectedParams: map[string]interface{}{
+				"Name": "test-param",
+				"Args": map[string]interface{}{
+					"first":  "first-arg",
+					"second": "second-arg",
+				},
+				"A": "B",
+				"C": map[string]interface{}{
+					"D": "E",
+					"F": "G",
+				},
+			},
+			expectedConditionStatus: v1beta1.ConditionTrue,
+			expectedConditionReason: "ProvisionedSuccessfully",
+		},
+		"missing secret": {
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			expectedConditionStatus: v1beta1.ConditionFalse,
+			expectedConditionReason: "ErrorWithParameters",
+		},
+		"missing secret key": {
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "other-secret-key",
+					},
+				},
+			},
+			secret: secretDef{
+				name: "secret-name",
+				data: map[string][]byte{
+					"secret-key": []byte(`bad`),
+				},
+			},
+			expectedConditionStatus: v1beta1.ConditionFalse,
+			expectedConditionReason: "ErrorWithParameters",
+		},
+		"empty secret data": {
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secret: secretDef{
+				name: "secret-name",
+				data: map[string][]byte{},
+			},
+			expectedConditionStatus: v1beta1.ConditionFalse,
+			expectedConditionReason: "ErrorWithParameters",
+		},
+		"bad secret data": {
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secret: secretDef{
+				name: "secret-name",
+				data: map[string][]byte{
+					"secret-key": []byte(`bad`),
+				},
+			},
+			expectedConditionStatus: v1beta1.ConditionFalse,
+			expectedConditionReason: "ErrorWithParameters",
+		},
+		"no params in secret data": {
+			paramsFrom: []v1beta1.ParametersFromSource{
+				{
+					SecretKeyRef: &v1beta1.SecretKeyReference{
+						Name: "secret-name",
+						Key:  "secret-key",
+					},
+				},
+			},
+			secret: secretDef{
+				name: "secret-name",
+				data: map[string][]byte{
+					"secret-key": []byte(`{}`),
+				},
+			},
+			expectedParams:          nil,
+			expectedConditionStatus: v1beta1.ConditionTrue,
+			expectedConditionReason: "ProvisionedSuccessfully",
+		},
+	} {
+		t.Run(tn, func(t *testing.T) {
+			// GIVEN
+			ct := newControllerTest(t)
+			defer ct.TearDown()
+
+			require.NoError(t, ct.CreateSimpleClusterServiceBroker())
+			require.NoError(t, ct.WaitForReadyBroker())
+
+			// WHEN
+			_, err := ct.CreateServiceInstanceWithParameters(state.params, state.paramsFrom)
+			require.NoError(t, err)
+			require.NoError(t, ct.CreateSecret(state.secret.name, state.secret.data))
+
+			// THEN
+			condition := v1beta1.ServiceInstanceCondition{
+				Type:   v1beta1.ServiceInstanceConditionReady,
+				Status: state.expectedConditionStatus,
+				Reason: state.expectedConditionReason,
+			}
+			require.NoError(t, ct.WaitForInstanceCondition(condition))
+
+			if state.expectedConditionStatus == v1beta1.ConditionTrue {
+				ct.AssertLastBindRequest(t, state.expectedParams)
+			}
+		})
+	}
+}
+
+// TestCreateServiceInstanceWithProvisionFailure tests creating a ServiceInstance
+// with various failure results in response to the provision request.
+func TestCreateServiceInstanceWithProvisionFailure(t *testing.T) {
+	for tn, state := range map[string]struct {
+		orphanMitigation            bool
+		provisionResponseStatusCode int
+		firstFailedReason           string
+		orphanMitigationReason      string
+		failReason                  string
+		nonHTTPResponseError        error
+	}{
+		"Status OK": {
+			orphanMitigation:            false,
+			provisionResponseStatusCode: http.StatusOK,
+			firstFailedReason:           "ProvisionCallFailed",
+		},
+		"Status Created": {
+			orphanMitigation:            true,
+			provisionResponseStatusCode: http.StatusCreated,
+			firstFailedReason:           "StartingInstanceOrphanMitigation",
+		},
+		"Other 2xx": {
+			orphanMitigation:            true,
+			provisionResponseStatusCode: http.StatusNoContent,
+			firstFailedReason:           "StartingInstanceOrphanMitigation",
+		},
+		"3XX": {
+			orphanMitigation:            false,
+			provisionResponseStatusCode: http.StatusMultipleChoices,
+			firstFailedReason:           "ProvisionCallFailed",
+		},
+		"Status Request Timeout": {
+			orphanMitigation:            false,
+			provisionResponseStatusCode: http.StatusRequestTimeout,
+			firstFailedReason:           "ProvisionCallFailed",
+		},
+		"400": {
+			orphanMitigation:            false,
+			provisionResponseStatusCode: http.StatusBadRequest,
+			firstFailedReason:           "ProvisionCallFailed",
+			failReason:                  "ClusterServiceBrokerReturnedFailure",
+		},
+		"Other 4XX": {
+			orphanMitigation:            false,
+			provisionResponseStatusCode: http.StatusForbidden,
+			firstFailedReason:           "ProvisionCallFailed",
+		},
+		"5XX": {
+			orphanMitigation:            true,
+			provisionResponseStatusCode: http.StatusInternalServerError,
+			firstFailedReason:           "StartingInstanceOrphanMitigation",
+		},
+		"Non url transport error": {
+			orphanMitigation:     false,
+			nonHTTPResponseError: fmt.Errorf("non-url error"),
+			firstFailedReason:    "ErrorCallingProvision",
+		},
+		"Non timeout url error": {
+			orphanMitigation: false,
+			nonHTTPResponseError: &url.Error{
+				Op:  "Put",
+				URL: "https://fakebroker.com/v2/service_instances/instance_id",
+				Err: fmt.Errorf("non-timeout error"),
+			},
+			firstFailedReason: "ErrorCallingProvision",
+		},
+		"Network timeout": {
+			orphanMitigation: true,
+			nonHTTPResponseError: &url.Error{
+				Op:  "Put",
+				URL: "https://fakebroker.com/v2/service_instances/instance_id",
+				Err: TimeoutError("timeout error"),
+			},
+			firstFailedReason:      "StartingInstanceOrphanMitigation",
+			orphanMitigationReason: "ErrorCallingProvision",
+		},
+	} {
+		t.Run(tn, func(t *testing.T) {
+			// GIVEN
+			ct := newControllerTest(t)
+			defer ct.TearDown()
+
+			require.NoError(t, ct.CreateSimpleClusterServiceBroker())
+			require.NoError(t, ct.WaitForReadyBroker())
+
+			blockDeprovisioning := make(chan bool)
+
+			// WHEN
+			if state.nonHTTPResponseError != nil {
+				ct.SetCustomErrorReactionForProvisioningToOSBClient(state.nonHTTPResponseError)
+			} else {
+				ct.SetErrorReactionForProvisioningToOSBClient(state.provisionResponseStatusCode)
+			}
+			ct.SetErrorReactionForDeprovisioningToOSBClient(http.StatusInternalServerError, blockDeprovisioning)
+			require.NoError(t, ct.CreateServiceInstance())
+
+			// THEN
+			// Wait for the provision to fail
+			condition := v1beta1.ServiceInstanceCondition{
+				Type:   v1beta1.ServiceInstanceConditionReady,
+				Status: v1beta1.ConditionFalse,
+				Reason: state.firstFailedReason,
+			}
+			require.NoError(t, ct.WaitForInstanceCondition(condition))
+
+			// In original test next step is making sure that the latest generation has been observed
+			// it means `ObservedGeneration` parameters should be equal 1, here `ObservedGeneration` is equal 0
+			// because in original test apiserver is used and its functionality set `instance.Generation` to 1
+			// inside file `pkg/registry/servicecatalog/instance/strategy.go` method `PrepareForCreate()`.
+			// In this test the `instance.Generation` is not update so in `pkg/controller/controller_instance.go`
+			// in method `reconcileServiceInstanceAdd` will not increase `ObservedGeneration` value
+			// because `instance.Status.ObservedGeneration != instance.Generation` condition is not met
+
+			// If the provision failed with a terminating failure
+			if state.failReason != "" {
+				condition = v1beta1.ServiceInstanceCondition{
+					Type:   v1beta1.ServiceInstanceConditionFailed,
+					Status: v1beta1.ConditionTrue,
+					Reason: state.failReason,
+				}
+				require.NoError(t, ct.WaitForInstanceCondition(condition))
+				assert.Zero(t, ct.NumberOfOSBDeprovisionCalls())
+
+				return
+			}
+
+			// Assert that the orphan mitigation reason was set correctly
+			if state.orphanMitigation {
+				ct.AssertServiceInstanceOrphanMitigationStatus(t, true)
+				blockDeprovisioning <- false
+
+				condition = v1beta1.ServiceInstanceCondition{
+					Type:   v1beta1.ServiceInstanceConditionReady,
+					Status: v1beta1.ConditionUnknown,
+					Reason: "DeprovisionCallFailed",
+				}
+				require.NoError(t, ct.WaitForInstanceCondition(condition))
+			} else {
+				condition = v1beta1.ServiceInstanceCondition{
+					Type:   v1beta1.ServiceInstanceConditionOrphanMitigation,
+					Status: v1beta1.ConditionFalse,
+				}
+				ct.AssertServiceInstanceHasNoCondition(t, condition)
+				ct.AssertServiceInstanceOrphanMitigationStatus(t, false)
+			}
+
+			ct.SetSuccessfullyReactionForProvisioningToOSBClient()
+			ct.SetSuccessfullyReactionForDeprovisioningToOSBClient()
+
+			// Wait for the instance to be provisioned successfully
+			condition = v1beta1.ServiceInstanceCondition{
+				Type:   v1beta1.ServiceInstanceConditionReady,
+				Status: v1beta1.ConditionTrue,
+				Reason: "ProvisionedSuccessfully",
+			}
+			require.NoError(t, ct.WaitForInstanceCondition(condition))
+
+			// Assert that the observed generation is up-to-date, that orphan mitigation is not in progress,
+			// and that the instance is not in a failed state.
+			ct.AssertObservedGenerationIsCorrect(t)
+			ct.AssertServiceInstanceOrphanMitigationStatus(t, false)
+			condition = v1beta1.ServiceInstanceCondition{
+				Type:   v1beta1.ServiceInstanceConditionFailed,
+				Status: v1beta1.ConditionFalse,
+			}
+			ct.AssertServiceInstanceHasNoCondition(t, condition)
+			assert.NotZero(t, ct.NumberOfOSBProvisionCalls())
+		})
+	}
+}
+
+// TestUpdateServiceInstanceChangePlans tests changing plans for an existing
+// ServiceInstance.
+func TestUpdateServiceInstanceChangePlans(t *testing.T) {
+	const (
+		simpleErrorUpdateReaction = "returnSimpleErrorUpdateReaction"
+		errorUpdateReaction       = "returnErrorUpdateReaction"
+		asyncUpdateReaction       = "returnAsyncUpdateReaction"
+	)
+
+	for tn, state := range map[string]struct {
+		useExternalNames              bool
+		dynamicUpdateInstanceReaction string
+	}{
+		"External": {
+			useExternalNames: true,
+		},
+		"K8s": {
+			useExternalNames: false,
+		},
+		"External name with two update call failures": {
+			useExternalNames:              true,
+			dynamicUpdateInstanceReaction: simpleErrorUpdateReaction,
+		},
+		"External name with two update failures": {
+			useExternalNames:              true,
+			dynamicUpdateInstanceReaction: errorUpdateReaction,
+		},
+		"External name update response async": {
+			useExternalNames:              true,
+			dynamicUpdateInstanceReaction: asyncUpdateReaction,
+		},
+	} {
+		t.Run(tn, func(t *testing.T) {
+			// GIVEN
+			ct := newControllerTest(t)
+			defer ct.TearDown()
+
+			require.NoError(t, ct.CreateSimpleClusterServiceBroker())
+			require.NoError(t, ct.WaitForReadyBroker())
+			require.NoError(t, ct.WaitForClusterServiceClass())
+			require.NoError(t, ct.WaitForClusterServicePlan())
+
+			require.NoError(t, ct.CreateServiceInstance())
+			require.NoError(t, ct.WaitForReadyInstance())
+
+			switch state.dynamicUpdateInstanceReaction {
+			case simpleErrorUpdateReaction:
+				ct.SetSimpleErrorUpdateInstanceReaction()
+			case errorUpdateReaction:
+				ct.SetErrorUpdateInstanceReaction()
+			case asyncUpdateReaction:
+				ct.AsyncForInstanceUpdate()
+			}
+
+			var (
+				generation int64
+				err        error
+			)
+			// WHEN
+			if state.useExternalNames {
+				generation, err = ct.UpdateServiceInstanceExternalPlanName(testOtherPlanExternalID)
+			} else {
+				generation, err = ct.UpdateServiceInstanceInternalPlanName(testOtherClusterServicePlanName)
+			}
+			require.NoError(t, err)
+			require.NoError(t, ct.WaitForServiceInstanceProcessedGeneration(generation))
+
+			// THEN
+			assert.NotZero(t, ct.NumberOfOSBUpdateCalls())
+			ct.AssertLastOSBUpdatePlanID(t)
+		})
+	}
+}
+
+// TestUpdateServiceInstanceChangePlansToNonexistentPlan tests changing plans
+// to a non-existent plan.
+func TestUpdateServiceInstanceChangePlansToNonexistentPlan(t *testing.T) {
+	// GIVEN
+	ct := newControllerTest(t)
+	defer ct.TearDown()
+
+	require.NoError(t, ct.CreateSimpleClusterServiceBroker())
+	require.NoError(t, ct.WaitForReadyBroker())
+	require.NoError(t, ct.WaitForClusterServiceClass())
+	require.NoError(t, ct.WaitForClusterServicePlan())
+
+	require.NoError(t, ct.CreateServiceInstance())
+	require.NoError(t, ct.WaitForReadyInstance())
+
+	// WHEN
+	_, err := ct.UpdateServiceInstanceExternalPlanName("non-existing-plan-id")
+	require.NoError(t, err)
+
+	// THEN
+	condition := v1beta1.ServiceInstanceCondition{
+		Type:   v1beta1.ServiceInstanceConditionReady,
+		Status: v1beta1.ConditionFalse,
+		Reason: "ReferencesNonexistentServicePlan",
+	}
+	require.NoError(t, ct.WaitForInstanceCondition(condition))
+}
+
+// TestUpdateServiceInstanceNewDashboardResponse tests setting Dashboard URL when
+// and update Instance request returns a new DashboardURL.
+func TestUpdateServiceInstanceNewDashboardResponse(t *testing.T) {
+	for tn, state := range map[string]struct {
+		enableFeatureGate bool
+	}{
+		"Alpha features enabled": {
+			enableFeatureGate: true,
+		},
+		"Alpha feature disabled": {
+			enableFeatureGate: false,
+		},
+	} {
+		t.Run(tn, func(t *testing.T) {
+			// GIVEN
+			ct := newControllerTest(t)
+			defer ct.TearDown()
+
+			require.NoError(t, ct.SetFeatureGateDashboardURL(state.enableFeatureGate))
+			require.NoError(t, ct.CreateSimpleClusterServiceBroker())
+			require.NoError(t, ct.CreateServiceInstance())
+			require.NoError(t, ct.WaitForReadyInstance())
+			ct.SetUpdateServiceInstanceResponseWithDashboardURL()
+
+			// WHEN
+			require.NoError(t, ct.UpdateServiceInstanceParameters())
+			require.NoError(t, ct.WaitForReadyUpdateInstance())
+
+			// THEN
+			if state.enableFeatureGate {
+				ct.AssertServiceInstanceDashboardURL(t)
+			} else {
+				ct.AssertServiceInstanceEmptyDashboardURL(t)
+			}
+		})
+	}
+}
+
+// TestUpdateServiceInstanceUpdateParameters tests updating the parameters
+// of an existing ServiceInstance.
+func TestUpdateServiceInstanceUpdateParameters(t *testing.T) {
+	for tn, state := range map[string]struct {
+		instanceWithParams           bool
+		instanceWithParamsFromSecret bool
+		updateParams                 bool
+		updateParamsFromSecret       bool
+		deleteParams                 bool
+		deleteParamsFromSecret       bool
+		expectedParams               map[string]interface{}
+	}{
+		"Add param": {
+			updateParams:   true,
+			expectedParams: map[string]interface{}{"param-key": "new-param-value"},
+		},
+		"Update param": {
+			instanceWithParams: true,
+			updateParams:       true,
+			expectedParams:     map[string]interface{}{"param-key": "new-param-value"},
+		},
+		"Delete param": {
+			instanceWithParams: true,
+			deleteParams:       true,
+			expectedParams:     map[string]interface{}{},
+		},
+		"Add param with secret": {
+			instanceWithParamsFromSecret: true,
+			updateParams:                 true,
+			expectedParams: map[string]interface{}{
+				"secret-param-key": "secret-param-value",
+				"param-key":        "new-param-value"},
+		},
+		"Update param with secret": {
+			instanceWithParams:           true,
+			instanceWithParamsFromSecret: true,
+			updateParams:                 true,
+			expectedParams: map[string]interface{}{
+				"param-key":        "new-param-value",
+				"secret-param-key": "secret-param-value"},
+		},
+		"Delete param with secret": {
+			instanceWithParams:           true,
+			instanceWithParamsFromSecret: true,
+			deleteParams:                 true,
+			expectedParams:               map[string]interface{}{"secret-param-key": "secret-param-value"},
+		},
+		"Add secret param": {
+			instanceWithParamsFromSecret: true,
+			updateParamsFromSecret:       true,
+			expectedParams:               map[string]interface{}{"other-secret-param-key": "other-secret-param-value"},
+		},
+		"Update secret param": {
+			instanceWithParamsFromSecret: true,
+			updateParamsFromSecret:       true,
+			expectedParams:               map[string]interface{}{"other-secret-param-key": "other-secret-param-value"},
+		},
+		"Delete secret param": {
+			instanceWithParamsFromSecret: true,
+			deleteParamsFromSecret:       true,
+			expectedParams:               map[string]interface{}{},
+		},
+		"Add secret param with plain param": {
+			instanceWithParams:     true,
+			updateParamsFromSecret: true,
+			expectedParams: map[string]interface{}{
+				"param-key":              "param-value",
+				"other-secret-param-key": "other-secret-param-value"},
+		},
+		"Update secret param with plain param": {
+			instanceWithParams:           true,
+			instanceWithParamsFromSecret: true,
+			updateParamsFromSecret:       true,
+			expectedParams: map[string]interface{}{
+				"param-key":              "param-value",
+				"other-secret-param-key": "other-secret-param-value"},
+		},
+		"Delete secret param with plain param": {
+			instanceWithParams:           true,
+			instanceWithParamsFromSecret: true,
+			deleteParamsFromSecret:       true,
+			expectedParams:               map[string]interface{}{"param-key": "param-value"},
+		},
+		"Update secret": {
+			instanceWithParamsFromSecret: true,
+			updateParamsFromSecret:       true,
+			expectedParams:               map[string]interface{}{"other-secret-param-key": "other-secret-param-value"},
+		},
+		"Update secret with plain param": {
+			instanceWithParams:           true,
+			instanceWithParamsFromSecret: true,
+			updateParamsFromSecret:       true,
+			expectedParams: map[string]interface{}{
+				"param-key":              "param-value",
+				"other-secret-param-key": "other-secret-param-value"},
+		},
+		"Add plain and secret param": {
+			updateParams:           true,
+			updateParamsFromSecret: true,
+			expectedParams: map[string]interface{}{
+				"param-key":              "new-param-value",
+				"other-secret-param-key": "other-secret-param-value"},
+		},
+		"Update plain and secret param": {
+			instanceWithParams:           true,
+			instanceWithParamsFromSecret: true,
+			updateParams:                 true,
+			updateParamsFromSecret:       true,
+			expectedParams: map[string]interface{}{
+				"param-key":              "new-param-value",
+				"other-secret-param-key": "other-secret-param-value"},
+		},
+		"Delete plain and secret param": {
+			instanceWithParams:           true,
+			instanceWithParamsFromSecret: true,
+			deleteParams:                 true,
+			deleteParamsFromSecret:       true,
+			expectedParams:               map[string]interface{}{},
+		},
+	} {
+		t.Run(tn, func(t *testing.T) {
+			// GIVEN
+			ct := newControllerTest(t)
+			defer ct.TearDown()
+
+			require.NoError(t, ct.CreateSimpleClusterServiceBroker())
+			require.NoError(t, ct.WaitForReadyBroker())
+
+			require.NoError(t, ct.CreateSecretsForServiceInstanceWithSecretParams())
+
+			require.NoError(t, ct.CreateServiceInstanceWithCustomParameters(
+				state.instanceWithParams,
+				state.instanceWithParamsFromSecret))
+			require.NoError(t, ct.WaitForReadyInstance())
+
+			// WHEN
+			generation, err := ct.UpdateCustomServiceInstanceParameters(
+				state.updateParams,
+				state.updateParamsFromSecret,
+				state.deleteParams,
+				state.deleteParamsFromSecret)
+			require.NoError(t, err)
+			require.NoError(t, ct.WaitForServiceInstanceProcessedGeneration(generation))
+
+			// THEN
+			assert.NotZero(t, ct.NumberOfOSBUpdateCalls())
+			ct.AssertBrokerUpdateActionWithParametersExist(t, state.expectedParams)
 		})
 	}
 }

--- a/pkg/controller/controller_flow_instance_test.go
+++ b/pkg/controller/controller_flow_instance_test.go
@@ -47,6 +47,8 @@ func TestProvisionInstanceWithRetries(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			ct := newControllerTest(t)
 			defer ct.TearDown()
 			// configure first provision response with HTTP error
@@ -71,6 +73,8 @@ func TestProvisionInstanceWithRetries(t *testing.T) {
 // TestRetryAsyncDeprovision tests whether asynchronous deprovisioning retries
 // by attempting a new deprovision after failing.
 func TestRetryAsyncDeprovision(t *testing.T) {
+	t.Parallel()
+
 	// GIVEN
 	ct := newControllerTest(t)
 	defer ct.TearDown()
@@ -168,6 +172,8 @@ func TestServiceInstanceDeleteWithAsyncUpdateInProgress(t *testing.T) {
 // TestCreateServiceInstanceFailsWithNonexistentPlan tests creating a ServiceInstance whose ServicePlan
 // does not exist
 func TestCreateServiceInstanceFailsWithNonexistentPlan(t *testing.T) {
+	t.Parallel()
+
 	// GIVEN
 	ct := newControllerTest(t)
 	defer ct.TearDown()
@@ -191,6 +197,8 @@ func TestCreateServiceInstanceFailsWithNonexistentPlan(t *testing.T) {
 // TestCreateServiceInstanceNonExistentClusterServiceBroker tests creating a
 // ServiceInstance whose broker does not exist.
 func TestCreateServiceInstanceNonExistentClusterServiceBroker(t *testing.T) {
+	t.Parallel()
+
 	// GIVEN
 	ct := newControllerTest(t)
 	defer ct.TearDown()
@@ -216,12 +224,15 @@ func TestCreateServiceInstanceNonExistentClusterServiceBroker(t *testing.T) {
 // TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan tests that a ServiceInstance gets
 // a Failed condition when the service class or service plan it references does not exist.
 func TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan(t *testing.T) {
-	// TODO: cannot rewrite tests because fakeClient does not support `FieldSelector` during filtering ServiceInstance list
+	// TODO: test should be added after merging the CRDs, for now cannot rewrite tests because fakeClient does not support `FieldSelector` during filtering ServiceInstance list
+	t.Skip("Test skipped because fakeClient does not support `FieldSelector` during filtering ServiceInstance list")
 }
 
 // TestCreateServiceInstanceWithInvalidParameters tests creating a ServiceInstance
 // with invalid parameters.
 func TestCreateServiceInstanceWithInvalidParameters(t *testing.T) {
+	t.Parallel()
+
 	// GIVEN
 	ct := newControllerTest(t)
 	defer ct.TearDown()
@@ -428,6 +439,8 @@ func TestCreateServiceInstanceWithParameters(t *testing.T) {
 		},
 	} {
 		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
 			// GIVEN
 			ct := newControllerTest(t)
 			defer ct.TearDown()
@@ -533,6 +546,8 @@ func TestCreateServiceInstanceWithProvisionFailure(t *testing.T) {
 		},
 	} {
 		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
 			// GIVEN
 			ct := newControllerTest(t)
 			defer ct.TearDown()
@@ -659,6 +674,8 @@ func TestUpdateServiceInstanceChangePlans(t *testing.T) {
 		},
 	} {
 		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
 			// GIVEN
 			ct := newControllerTest(t)
 			defer ct.TearDown()
@@ -703,6 +720,8 @@ func TestUpdateServiceInstanceChangePlans(t *testing.T) {
 // TestUpdateServiceInstanceChangePlansToNonexistentPlan tests changing plans
 // to a non-existent plan.
 func TestUpdateServiceInstanceChangePlansToNonexistentPlan(t *testing.T) {
+	t.Parallel()
+
 	// GIVEN
 	ct := newControllerTest(t)
 	defer ct.TearDown()
@@ -730,6 +749,7 @@ func TestUpdateServiceInstanceChangePlansToNonexistentPlan(t *testing.T) {
 
 // TestUpdateServiceInstanceNewDashboardResponse tests setting Dashboard URL when
 // and update Instance request returns a new DashboardURL.
+// CAUTION: the test cannot run parallel because it changes global flag which can include on working other tests
 func TestUpdateServiceInstanceNewDashboardResponse(t *testing.T) {
 	for tn, state := range map[string]struct {
 		enableFeatureGate bool
@@ -747,6 +767,9 @@ func TestUpdateServiceInstanceNewDashboardResponse(t *testing.T) {
 			defer ct.TearDown()
 
 			require.NoError(t, ct.SetFeatureGateDashboardURL(state.enableFeatureGate))
+			// default value for defaultFuture is false
+			// see https://github.com/kubernetes/apiserver/blob/release-1.14/pkg/util/feature/feature_gate.go
+			defer require.NoError(t, ct.SetFeatureGateDashboardURL(false))
 			require.NoError(t, ct.CreateSimpleClusterServiceBroker())
 			require.NoError(t, ct.CreateServiceInstance())
 			require.NoError(t, ct.WaitForReadyInstance())
@@ -887,6 +910,8 @@ func TestUpdateServiceInstanceUpdateParameters(t *testing.T) {
 		},
 	} {
 		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
 			// GIVEN
 			ct := newControllerTest(t)
 			defer ct.TearDown()

--- a/pkg/controller/controller_flow_test.go
+++ b/pkg/controller/controller_flow_test.go
@@ -60,6 +60,7 @@ func TestBasicFlowWithBasicAuth(t *testing.T) {
 }
 
 // TestOriginatingIdentity tests whether the controller uses correct credentials when the secret changes
+// CAUTION: the test cannot be executed in parallel because it changes global flag which can affect the behavior of other tests
 func TestOriginatingIdentity(t *testing.T) {
 	// GIVEN
 	// Enable the OriginatingIdentity feature

--- a/pkg/controller/controller_flow_test.go
+++ b/pkg/controller/controller_flow_test.go
@@ -22,12 +22,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	scfeatures "github.com/kubernetes-sigs/service-catalog/pkg/features"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-
-	"github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
 )
 
 // TestBasicFlowWithBasicAuth tests whether the controller uses correct credentials when the secret changes


### PR DESCRIPTION
This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
The PR indroduces controller tests which will replace current integration tests, see #2597
Test refers to the ServiceInstance flow:

- TestCreateServiceInstanceFailsWithNonexistentPlan
- TestCreateServiceInstanceNonExistentClusterServiceBroker
- TestCreateServiceInstanceNonExistentClusterServiceClassOrPlan
- TestCreateServiceInstanceWithInvalidParameters
- TestCreateServiceInstanceWithParameters
- TestCreateServiceInstanceWithProvisionFailure
- TestUpdateServiceInstanceChangePlans
- TestUpdateServiceInstanceChangePlansToNonexistentPlan
- TestUpdateServiceInstanceNewDashboardResponse
- TestUpdateServiceInstanceUpdateParameters

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
