### PR TITLE
Send 'previous_values' field in update service instance request body

### DIFF
--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -2269,6 +2269,10 @@ func (c *controller) prepareUpdateInstanceRequest(instance *v1beta1.ServiceInsta
 			ServiceID:           serviceClass.Spec.ExternalID,
 			Context:             rh.requestContext,
 			OriginatingIdentity: rh.originatingIdentity,
+			PreviousValues: &osb.PreviousValues{
+				PlanID:    instance.Status.ExternalProperties.ClusterServicePlanExternalID,
+				ServiceID: serviceClass.Spec.ExternalID,
+			},
 		}
 
 		// Only send the plan ID if the plan ID has changed from what the Broker has
@@ -2304,6 +2308,10 @@ func (c *controller) prepareUpdateInstanceRequest(instance *v1beta1.ServiceInsta
 			ServiceID:           serviceClass.Spec.ExternalID,
 			Context:             rh.requestContext,
 			OriginatingIdentity: rh.originatingIdentity,
+			PreviousValues: &osb.PreviousValues{
+				PlanID:    instance.Status.ExternalProperties.ClusterServicePlanExternalID,
+				ServiceID: serviceClass.Spec.ExternalID,
+			},
 		}
 
 		// Only send the plan ID if the plan ID has changed from what the Broker has

--- a/pkg/controller/controller_instance_test.go
+++ b/pkg/controller/controller_instance_test.go
@@ -4675,6 +4675,7 @@ func TestReconcileServiceInstanceUpdateParameters(t *testing.T) {
 			},
 			"name": "test-param",
 		},
+		PreviousValues: &osb.PreviousValues{PlanID: testClusterServicePlanGUID, ServiceID: testClusterServiceClassGUID},
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -4772,6 +4773,7 @@ func TestReconcileServiceInstanceDeleteParameters(t *testing.T) {
 		PlanID:            nil, // no change to plan
 		Context:           testContext,
 		Parameters:        make(map[string]interface{}),
+		PreviousValues:    &osb.PreviousValues{PlanID: testClusterServicePlanGUID, ServiceID: testClusterServiceClassGUID},
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -4995,6 +4997,7 @@ func TestReconcileServiceInstanceUpdateDashboardURLResponse(t *testing.T) {
 			PlanID:            &expectedPlanID,
 			Context:           testContext,
 			Parameters:        nil, // no change to parameters
+			PreviousValues:    &osb.PreviousValues{PlanID: "old-plan-id", ServiceID: testClusterServiceClassGUID},
 		})
 
 		actions := fakeCatalogClient.Actions()
@@ -5106,6 +5109,7 @@ func TestReconcileServiceInstanceUpdatePlan(t *testing.T) {
 		PlanID:            &expectedPlanID,
 		Context:           testContext,
 		Parameters:        nil, // no change to parameters
+		PreviousValues:    &osb.PreviousValues{PlanID: "old-plan-id", ServiceID: testClusterServiceClassGUID},
 	})
 
 	actions := fakeCatalogClient.Actions()
@@ -5176,7 +5180,9 @@ func TestReconcileServiceInstanceWithUpdateCallFailure(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
-		Context:           testContext})
+		Context:           testContext,
+		PreviousValues:    &osb.PreviousValues{PlanID: "old-plan-id", ServiceID: testClusterServiceClassGUID},
+	})
 
 	// verify no kube resources created
 	// One single action comes from getting namespace uid
@@ -5275,7 +5281,9 @@ func TestReconcileServiceInstanceWithUpdateFailure(t *testing.T) {
 				InstanceID:        testServiceInstanceGUID,
 				ServiceID:         testClusterServiceClassGUID,
 				PlanID:            &expectedPlanID,
-				Context:           testContext})
+				Context:           testContext,
+				PreviousValues:    &osb.PreviousValues{PlanID: "old-plan-id", ServiceID: testClusterServiceClassGUID},
+			})
 
 			// verify one kube action occurred
 			kubeActions := fakeKubeClient.Actions()
@@ -5545,7 +5553,9 @@ func TestReconcileServiceInstanceUpdateAsynchronous(t *testing.T) {
 		InstanceID:        testServiceInstanceGUID,
 		ServiceID:         testClusterServiceClassGUID,
 		PlanID:            &expectedPlanID,
-		Context:           testContext})
+		Context:           testContext,
+		PreviousValues:    &osb.PreviousValues{PlanID: "old-plan-id", ServiceID: testClusterServiceClassGUID},
+	})
 
 	actions := fakeCatalogClient.Actions()
 	assertNumberOfActions(t, actions, 1)


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-sigs/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-sigs/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
Send 'previous_values' field in update service instance request body

**Which issue(s) this PR fixes** 
Fixes #2524

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
