### PR TITLE
Changed walkthrough from UPS to mini

### DIFF
--- a/contrib/examples/walkthrough/mini-binding.yaml
+++ b/contrib/examples/walkthrough/mini-binding.yaml
@@ -1,8 +1,8 @@
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServiceBinding
 metadata:
-  name: ups-binding
+  name: mini-binding
   namespace: test-ns
 spec:
   instanceRef:
-    name: ups-instance
+    name: mini-instance

--- a/contrib/examples/walkthrough/mini-instance.yaml
+++ b/contrib/examples/walkthrough/mini-instance.yaml
@@ -1,11 +1,11 @@
 apiVersion: servicecatalog.k8s.io/v1beta1
 kind: ServiceInstance
 metadata:
-  name: ups-instance
+  name: mini-instance
   namespace: test-ns
 spec:
-  clusterServiceClassExternalName: user-provided-service
-  clusterServicePlanExternalName: default
+  clusterServiceClassExternalName: mariadb
+  clusterServicePlanExternalName: 10-1-26
   parameters:
     param-1: value-1
     param-2: value-2


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-sigs/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-sigs/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [ ] Bug Fix
 - [X] Documentation

**What this PR does / why we need it**:
Requested change from UPS Broker to Minibroker within walkthrough.

**Which issue(s) this PR fixes** 
Fixes #2658

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
