### PR TITLE
Update docker image tag

### DIFF
--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Service Catalog
 # service-catalog image to use
-image: quay.io/kubernetes-service-catalog/service-catalog:v0.2.1
+image: quay.io/kubernetes-service-catalog/service-catalog:canary
 # imagePullPolicy for the service-catalog; valid values are "IfNotPresent",
 # "Never", and "Always"
 imagePullPolicy: Always


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
Currently chart installation from master branch is broken: arguments defined in Helm chart are incompatible with binary in docker image.

To replicate this issue install SC from source:
```
helm install --name catalog --namespace default charts/catalog/ --wait
```
And check controller-manager logs:
```
Error: unknown flag: --osb-api-request-timeout
```

This PR sets docker image version to `canary`. This way installation from master will be always up to date.

**Which issue(s) this PR fixes** 

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
