### PR TITLE
State in the documetation that svc-cat depends on k8s v1.13+

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -11,7 +11,7 @@ For more information,
 
 ## Prerequisites
 
-- Kubernetes 1.12+
+- Kubernetes 1.13+
 - `charts/catalog` already exists in your local machine
 
 ## Installing the Chart

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,7 +16,7 @@ The rest of this document details how to:
 
 ## Kubernetes Version
 
-Service Catalog requires a Kubernetes cluster v1.12 or later. You'll also need a
+Service Catalog requires a Kubernetes cluster v1.13 or later. You'll also need a
 [Kubernetes configuration file](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
 installed on your host. You need this file so you can use `kubectl` and
 [`helm`](https://helm.sh) to communicate with the cluster. Many Kubernetes installation
@@ -27,7 +27,7 @@ check with your tool or provider for details.
 
 Most interaction with the service catalog system is achieved through the
 `kubectl` command line interface. As with the cluster version, Service Catalog
-requires `kubectl` version 1.12 or newer.
+requires `kubectl` version 1.13 or newer.
 
 First, check your version of `kubectl`:
 
@@ -35,7 +35,7 @@ First, check your version of `kubectl`:
 kubectl version
 ```
 
-Ensure that the server version and client versions are both `1.12` or above.
+Ensure that the server version and client versions are both `1.13` or above.
 
 If you need to upgrade your client, follow the
 [installation instructions](https://kubernetes.io/docs/tasks/kubectl/install/)


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-sigs/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-sigs/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [ ] Bug Fix
 - [x] Documentation

**What this PR does / why we need it**:
Improve documentation to make it clear that service catalog requires k8s cluster of version `v1.13` or newer.

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #2678 

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
