### PR TITLE
Update regex to allow "-beta.X" releases

### DIFF
--- a/contrib/hack/ci/publish-release.sh
+++ b/contrib/hack/ci/publish-release.sh
@@ -29,7 +29,7 @@ docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
 
 pushd ${REPO_ROOT_DIR}
 
-if [[ "${TRAVIS_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[a-z]*(-(r|R)(c|C)[0-9]+)*$ ]]; then
+if [[ "${TRAVIS_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[a-z]*((-beta.[0-9]+)|(-(r|R)(c|C)[0-9]+))?$ ]]; then
     shout "Pushing images with tags '${TRAVIS_TAG}' and 'latest'."
     TAG_VERSION="${TRAVIS_TAG}" VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make release-push svcat-publish
 elif [[ "${TRAVIS_BRANCH}" == "master" ]]; then


### PR DESCRIPTION
This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
It updates regex validating release names to accept releases with names like  "0.2.0-beta.0"

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
