### PR TITLE
Bump Service Catalog release to 0.3.0-beta.0

### DIFF
--- a/charts/catalog/Chart.yaml
+++ b/charts/catalog/Chart.yaml
@@ -1,3 +1,3 @@
 name: catalog
-description: service-catalog API server and controller-manager helm chart
-version: 0.2.2
+description: service-catalog webhook server and controller-manager helm chart
+version: 0.3.0-beta.0

--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -40,7 +40,7 @@ chart and their default values.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | Service catalog image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.2.2` |
+| `image` | Service catalog image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-beta.0` |
 | `imagePullPolicy` | `imagePullPolicy` for the service catalog | `Always` |
 | `webhook.updateStrategy` | `updateStrategy` for the service catalog webhook deployment | `RollingUpdate` |
 | `webhook.minReadySeconds` | how many seconds an webhook server pod needs to be ready before killing the next, during update | `1` |

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Service Catalog
 # service-catalog image to use
-image: quay.io/kubernetes-service-catalog/service-catalog:v0.2.2
+image: quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-beta.0
 # imagePullPolicy for the service-catalog; valid values are "IfNotPresent",
 # "Never", and "Always"
 imagePullPolicy: Always

--- a/charts/healthcheck/Chart.yaml
+++ b/charts/healthcheck/Chart.yaml
@@ -1,3 +1,3 @@
 name: healthcheck
 description: HealthCheck monitors the health of Service Catalog
-version: 0.2.2
+version: 0.3.0-beta.0

--- a/charts/healthcheck/values.yaml
+++ b/charts/healthcheck/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Health Check
 # Image to use
-image: quay.io/kubernetes-service-catalog/healthcheck:v0.2.2
+image: quay.io/kubernetes-service-catalog/healthcheck:v0.3.0-beta.0
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: IfNotPresent
 rbacApiVersion: rbac.authorization.k8s.io/v1

--- a/charts/test-broker/Chart.yaml
+++ b/charts/test-broker/Chart.yaml
@@ -1,3 +1,3 @@
 name: test-broker
 description: test service-broker deployment Helm chart.
-version: 0.2.2
+version: 0.3.0-beta.0

--- a/charts/test-broker/README.md
+++ b/charts/test-broker/README.md
@@ -54,7 +54,7 @@ Service Broker
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | Image to use | `quay.io/kubernetes-service-catalog/test-broker:v0.2.2` |
+| `image` | Image to use | `quay.io/kubernetes-service-catalog/test-broker:v0.3.0-beta.0` |
 | `imagePullPolicy` | `imagePullPolicy` for the test-broker | `Always` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to

--- a/charts/test-broker/values.yaml
+++ b/charts/test-broker/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Test Service Broker
 # Image to use
-image: quay.io/kubernetes-service-catalog/test-broker:v0.2.2
+image: quay.io/kubernetes-service-catalog/test-broker:v0.3.0-beta.0
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: Always
 # Whether the broker should also log to stderr instead of to files only

--- a/charts/ups-broker/Chart.yaml
+++ b/charts/ups-broker/Chart.yaml
@@ -1,3 +1,3 @@
 name: ups-broker
 description: user-provided service-broker deployment Helm chart.
-version: 0.2.2
+version: 0.3.0-beta.0

--- a/charts/ups-broker/README.md
+++ b/charts/ups-broker/README.md
@@ -34,7 +34,7 @@ Service Broker
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | Image to use | `quay.io/kubernetes-service-catalog/user-broker:v0.2.2` |
+| `image` | Image to use | `quay.io/kubernetes-service-catalog/user-broker:v0.3.0-beta.0` |
 | `imagePullPolicy` | `imagePullPolicy` for the ups-broker | `Always` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to

--- a/charts/ups-broker/values.yaml
+++ b/charts/ups-broker/values.yaml
@@ -1,6 +1,6 @@
 # Default values for User-Provided Service Broker
 # Image to use
-image: quay.io/kubernetes-service-catalog/user-broker:v0.2.2
+image: quay.io/kubernetes-service-catalog/user-broker:v0.3.0-beta.0
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: Always
 # Whether the broker should also log to stderr instead of to files only


### PR DESCRIPTION
**Description**

This PR bumps Service Catalog to 0.3.0-beta.0 release. 

**Release notes which will be added to GitHub release:**

--- 
🚨Service Catalog v0.3.0-beta.0 is now available! This is the first beta release for Service Catalog 0.3.0 milestone.

In this release, we've focused on replacing the Aggregated API Server with the CustomResourceDefinitions (CRDs) and Admission Webhook solution. The whole [Service Catalog documentation](https://svc-cat.io) is already updated. Check it out for more details.

To install the Service Catalog from this release, run:
```
helm install svc-cat/catalog —version 0.3.0-beta.0
```

If you have installed Service Catalog on your cluster using the `helm install svc-cat/catalog` command, then migration process is automated for you and you can just run:
```
helm upgrade <release_name> svc-cat/catalog --version 0.3.0-beta.0
```
The migration process is described [here](https://svc-cat.io/docs/migration-apiserver-to-crds/) in details. There you will also find information on how to upgrade Service Catalog manually.

**We'd really appreciate any feedback on the upgrade procedure and any issues or tips you may run into.**

# Changes
- Update the run-migration-tests.sh script (#2710)
- Adjust test after fixing the repetitive update issue  (#2710)
- Create script for executing migration tests on CI  (#2710)
- Fix webhook definition in migration code after introduction k8s 1.15  (#2710)
- Update doc about migration from apiserver to crd  (#2710)
- Move creating PVC functionality to migration tool  (#2710)
- Add option to rollback to the previous SC version  (#2710)
- Blocks mutations of CRDs during backup  (#2710)
- Service Catalog upgrade tester  (#2710)
- Add migration job to chart  (#2710)
- Update migration docs  (#2710)
- Migrate apiserver to crds  (#2710)
- Replaces the Aggregated A PI Server with the CustomResourceDefinitions (CRDs) solution (#2630)
- Change controller manager deployment charts template (#2708)
- svc-cat depends on k8s v1.13+ (#2703)
- change pmorie lib import to kubernetes-sigs location (#2702)
- bump chart versions to 0.2.2 (#2699)
- Add controller Service Instance test (#2667)
- Bump github.com/pmorie/go-open-service-broker-client dependency (#2689)
- Change creates statements in walkthrough.md (#2695)
- Add information about the current project status (#2691)


# SVCat Binaries
macOS: https://download.svcat.sh/cli/v0.3.0-beta.0/darwin/amd64/svcat
Windows: https://download.svcat.sh/cli/v0.3.0-beta.0/windows/amd64/svcat.exe
Linux: https://download.svcat.sh/cli/v0.3.0-beta.0/linux/amd64/svcat