### PR TITLE
Add support for imagePullSecrets to helm charts

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -42,6 +42,7 @@ chart and their default values.
 |-----------|-------------|---------|
 | `image` | Service catalog image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-beta.0` |
 | `imagePullPolicy` | `imagePullPolicy` for the service catalog | `Always` |
+| `imagePullSecrets`|  The pre-existing secrets to use to pull images from a private registry | `[]` | 
 | `webhook.updateStrategy` | `updateStrategy` for the service catalog webhook deployment | `RollingUpdate` |
 | `webhook.minReadySeconds` | how many seconds an webhook server pod needs to be ready before killing the next, during update | `1` |
 | `webhook.annotations` | Annotations for webhook pods | `{}` |

--- a/charts/catalog/templates/cleaner-job.yaml
+++ b/charts/catalog/templates/cleaner-job.yaml
@@ -90,6 +90,8 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: clean-job-account
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
       containers:
         - name: service-catalog
           image: {{ .Values.image }}

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -33,6 +33,8 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
       serviceAccountName: "{{ .Values.controllerManager.serviceAccount }}"
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
       containers:
       - name: controller-manager
         image: {{ .Values.image }}

--- a/charts/catalog/templates/migration-job.yaml
+++ b/charts/catalog/templates/migration-job.yaml
@@ -112,6 +112,8 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: migration-job-account
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
       volumes:
       - name: storage
         persistentVolumeClaim:

--- a/charts/catalog/templates/pre-migration-job.yaml
+++ b/charts/catalog/templates/pre-migration-job.yaml
@@ -122,6 +122,8 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: pre-migration-job-account
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
       volumes:
       - name: storage
         persistentVolumeClaim:

--- a/charts/catalog/templates/webhook-deployment.yaml
+++ b/charts/catalog/templates/webhook-deployment.yaml
@@ -29,6 +29,8 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: "{{ .Values.webhook.serviceAccount }}"
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
       containers:
       - name: svr
         image: {{ .Values.image }}

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -1,6 +1,8 @@
 # Default values for Service Catalog
 # service-catalog image to use
 image: quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-beta.0
+# imagePullSecrets pre-existing secrets to use to pull images from a private registry
+imagePullSecrets: []
 # imagePullPolicy for the service-catalog; valid values are "IfNotPresent",
 # "Never", and "Always"
 imagePullPolicy: Always

--- a/charts/healthcheck/templates/healthcheck-deployment.yaml
+++ b/charts/healthcheck/templates/healthcheck-deployment.yaml
@@ -21,6 +21,8 @@ spec:
         heritage: "{{ .Release.Service }}"
     spec:
       serviceAccountName: "service-catalog-healthcheck"
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
       containers:
       - name: healthcheck
         image: {{ .Values.image }}

--- a/charts/healthcheck/values.yaml
+++ b/charts/healthcheck/values.yaml
@@ -1,6 +1,8 @@
 # Default values for Health Check
 # Image to use
 image: quay.io/kubernetes-service-catalog/healthcheck:v0.3.0-beta.0
+# imagePullSecrets pre-existing secrets to use to pull images from a private registry
+imagePullSecrets: []
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: IfNotPresent
 rbacApiVersion: rbac.authorization.k8s.io/v1

--- a/charts/test-broker/README.md
+++ b/charts/test-broker/README.md
@@ -55,6 +55,7 @@ Service Broker
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image` | Image to use | `quay.io/kubernetes-service-catalog/test-broker:v0.3.0-beta.0` |
+| `imagePullSecrets`|  The pre-existing secrets to use to pull images from a private registry | `[]` |
 | `imagePullPolicy` | `imagePullPolicy` for the test-broker | `Always` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to

--- a/charts/test-broker/templates/broker-deployment.yaml
+++ b/charts/test-broker/templates/broker-deployment.yaml
@@ -20,6 +20,8 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
       containers:
       - name: test-broker
         image: {{ .Values.image }}

--- a/charts/test-broker/values.yaml
+++ b/charts/test-broker/values.yaml
@@ -1,6 +1,8 @@
 # Default values for Test Service Broker
 # Image to use
 image: quay.io/kubernetes-service-catalog/test-broker:v0.3.0-beta.0
+# imagePullSecrets pre-existing secrets to use to pull images from a private registry
+imagePullSecrets: []
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: Always
 # Whether the broker should also log to stderr instead of to files only

--- a/charts/ups-broker/README.md
+++ b/charts/ups-broker/README.md
@@ -35,6 +35,7 @@ Service Broker
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image` | Image to use | `quay.io/kubernetes-service-catalog/user-broker:v0.3.0-beta.0` |
+| `imagePullSecrets`|  The pre-existing secrets to use to pull images from a private registry | `[]` |
 | `imagePullPolicy` | `imagePullPolicy` for the ups-broker | `Always` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to

--- a/charts/ups-broker/templates/broker-deployment.yaml
+++ b/charts/ups-broker/templates/broker-deployment.yaml
@@ -20,6 +20,8 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
       containers:
       - name: ups-broker
         image: {{ .Values.image }}

--- a/charts/ups-broker/values.yaml
+++ b/charts/ups-broker/values.yaml
@@ -1,6 +1,8 @@
 # Default values for User-Provided Service Broker
 # Image to use
 image: quay.io/kubernetes-service-catalog/user-broker:v0.3.0-beta.0
+# imagePullSecrets pre-existing secrets to use to pull images from a private registry
+imagePullSecrets: []
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: Always
 # Whether the broker should also log to stderr instead of to files only


### PR DESCRIPTION
Co-authored-by: Chris Whitty <cwhitty@pivotal.io>

This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
This PR adds support for `imagePullSecrets`([ref](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)) to all charts.

Notes:
* We have added this to value to all charts that allow you to specify `image`. 
* We decided not to follow the [pattern bitnami use](https://github.com/bitnami/charts/blob/master/bitnami/kafka/values.yaml#L28), since it means creating a nesting image object and would require a breaking change to existing image values in the values.yaml.

**Which issue(s) this PR fixes** 
Fixes #2712

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [x] New feature 
   - [ ] Tests
   - [x] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [x] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
