### PR TITLE
Bump Service Catalog release to 0.3.0-beta.1

### DIFF
--- a/charts/catalog/Chart.yaml
+++ b/charts/catalog/Chart.yaml
@@ -1,3 +1,3 @@
 name: catalog
 description: service-catalog webhook server and controller-manager helm chart
-version: 0.3.0-beta.0
+version: 0.3.0-beta.1

--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -40,7 +40,7 @@ chart and their default values.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | Service catalog image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-beta.0` |
+| `image` | Service catalog image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-beta.1` |
 | `imagePullPolicy` | `imagePullPolicy` for the service catalog | `Always` |
 | `imagePullSecrets`|  The pre-existing secrets to use to pull images from a private registry | `[]` | 
 | `webhook.updateStrategy` | `updateStrategy` for the service catalog webhook deployment | `RollingUpdate` |

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Service Catalog
 # service-catalog image to use
-image: quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-beta.0
+image: quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-beta.1
 # imagePullSecrets pre-existing secrets to use to pull images from a private registry
 imagePullSecrets: []
 # imagePullPolicy for the service-catalog; valid values are "IfNotPresent",

--- a/charts/healthcheck/Chart.yaml
+++ b/charts/healthcheck/Chart.yaml
@@ -1,3 +1,3 @@
 name: healthcheck
 description: HealthCheck monitors the health of Service Catalog
-version: 0.3.0-beta.0
+version: 0.3.0-beta.1

--- a/charts/healthcheck/values.yaml
+++ b/charts/healthcheck/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Health Check
 # Image to use
-image: quay.io/kubernetes-service-catalog/healthcheck:v0.3.0-beta.0
+image: quay.io/kubernetes-service-catalog/healthcheck:v0.3.0-beta.1
 # imagePullSecrets pre-existing secrets to use to pull images from a private registry
 imagePullSecrets: []
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"

--- a/charts/test-broker/Chart.yaml
+++ b/charts/test-broker/Chart.yaml
@@ -1,3 +1,3 @@
 name: test-broker
 description: test service-broker deployment Helm chart.
-version: 0.3.0-beta.0
+version: 0.3.0-beta.1

--- a/charts/test-broker/README.md
+++ b/charts/test-broker/README.md
@@ -54,7 +54,7 @@ Service Broker
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | Image to use | `quay.io/kubernetes-service-catalog/test-broker:v0.3.0-beta.0` |
+| `image` | Image to use | `quay.io/kubernetes-service-catalog/test-broker:v0.3.0-beta.1` |
 | `imagePullSecrets`|  The pre-existing secrets to use to pull images from a private registry | `[]` |
 | `imagePullPolicy` | `imagePullPolicy` for the test-broker | `Always` |
 

--- a/charts/test-broker/values.yaml
+++ b/charts/test-broker/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Test Service Broker
 # Image to use
-image: quay.io/kubernetes-service-catalog/test-broker:v0.3.0-beta.0
+image: quay.io/kubernetes-service-catalog/test-broker:v0.3.0-beta.1
 # imagePullSecrets pre-existing secrets to use to pull images from a private registry
 imagePullSecrets: []
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"

--- a/charts/ups-broker/Chart.yaml
+++ b/charts/ups-broker/Chart.yaml
@@ -1,3 +1,3 @@
 name: ups-broker
 description: user-provided service-broker deployment Helm chart.
-version: 0.3.0-beta.0
+version: 0.3.0-beta.1

--- a/charts/ups-broker/README.md
+++ b/charts/ups-broker/README.md
@@ -34,7 +34,7 @@ Service Broker
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | Image to use | `quay.io/kubernetes-service-catalog/user-broker:v0.3.0-beta.0` |
+| `image` | Image to use | `quay.io/kubernetes-service-catalog/user-broker:v0.3.0-beta.1` |
 | `imagePullSecrets`|  The pre-existing secrets to use to pull images from a private registry | `[]` |
 | `imagePullPolicy` | `imagePullPolicy` for the ups-broker | `Always` |
 

--- a/charts/ups-broker/values.yaml
+++ b/charts/ups-broker/values.yaml
@@ -1,6 +1,6 @@
 # Default values for User-Provided Service Broker
 # Image to use
-image: quay.io/kubernetes-service-catalog/user-broker:v0.3.0-beta.0
+image: quay.io/kubernetes-service-catalog/user-broker:v0.3.0-beta.1
 # imagePullSecrets pre-existing secrets to use to pull images from a private registry
 imagePullSecrets: []
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"


### PR DESCRIPTION
 **Description**

- Bump Service Catalog release to 0.3.0-beta.1

**RELEASE NOTES:**
---

🚨Service Catalog v0.3.0-beta.1 is now available! 

In this second beta release for the Service Catalog 0.3.0 milestone, we have worked on the following:

- Add missing `svcat: "true"` labels to Service Catalog CRDs
- Add CRD waiter for the migration job and the webhook server.
   It may take some time before Catalog CRDs are registered in the main API Server. For this reason, the CRD waiter is executed at the initial state of each Service Catalog binary because Service Catalog clients/informers can be created only when CRDs are available.
    
    Additionally, we added retries when restoring Service Catalog resources during the migration process.

    See the discussion in this thread for more info: 
    https://kubernetes.slack.com/archives/C232SF3TK/p1570107013007500

- Add iteration gap for readiness/liveness probe executions which are checking if CRDs for ServiceCatalog exist. Previously, the probes were executed every 10 secs, which generates a heavy load on the main API Server. 

- Previously, we listed all K8s CRDs. Now we fetch only CRDs which belong to Service Catalog using proper label selector. As a result, the response uses fewer resources.

**Check [beta.0](https://github.com/kubernetes-sigs/service-catalog/releases/tag/v0.3.0-beta.0) for more release notes.**

_We'd really appreciate any feedback on the upgrade procedure and any issues or tips you may run into._

# Changes since [beta.0](https://github.com/kubernetes-sigs/service-catalog/releases/tag/v0.3.0-beta.0)

- Add support for imagePullSecrets to helm charts (#2721) 
- Improve CRD liveness/readiness probe (#2717)
- Add CRD waiter for migration job and webhook server (#2719)

# SVCat Binaries
macOS: https://download.svcat.sh/cli/v0.3.0-beta.1/darwin/amd64/svcat
Windows: https://download.svcat.sh/cli/v0.3.0-beta.1/windows/amd64/svcat.exe
Linux: https://download.svcat.sh/cli/v0.3.0-beta.1/linux/amd64/svcat
