### PR TITLE
Split the Service Catalog release job by arch type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,52 @@ jobs:
       deploy:
         skip_cleanup: true
         provider: script
-        script: contrib/hack/ci/publish-release.sh
+        script: contrib/hack/ci/publish-svc-cat-release.sh --arch amd64
+        on:
+          repo: kubernetes-sigs/service-catalog
+          all_branches: true
+    - stage: deploy
+      script: skip
+      deploy:
+        skip_cleanup: true
+        provider: script
+        script: contrib/hack/ci/publish-svc-cat-release.sh --arch arm
+        on:
+          repo: kubernetes-sigs/service-catalog
+          all_branches: true
+    - stage: deploy
+      script: skip
+      deploy:
+        skip_cleanup: true
+        provider: script
+        script: contrib/hack/ci/publish-svc-cat-release.sh --arch arm64
+        on:
+          repo: kubernetes-sigs/service-catalog
+          all_branches: true
+    - stage: deploy
+      script: skip
+      deploy:
+        skip_cleanup: true
+        provider: script
+        script: contrib/hack/ci/publish-svc-cat-release.sh --arch ppc64le
+        on:
+          repo: kubernetes-sigs/service-catalog
+          all_branches: true
+    - stage: deploy
+      script: skip
+      deploy:
+        skip_cleanup: true
+        provider: script
+        script: contrib/hack/ci/publish-svc-cat-release.sh --arch s390x
+        on:
+          repo: kubernetes-sigs/service-catalog
+          all_branches: true
+    - stage: deploy
+      script: skip
+      deploy:
+        skip_cleanup: true
+        provider: script
+        script: contrib/hack/ci/publish-svcat-cli-release.sh
         on:
           repo: kubernetes-sigs/service-catalog
           all_branches: true

--- a/contrib/hack/ci/publish-svc-cat-release.sh
+++ b/contrib/hack/ci/publish-svc-cat-release.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+readonly REPO_ROOT_DIR=${CURRENT_DIR}/../../../
+
+source "${CURRENT_DIR}/lib/utilities.sh" || { echo 'Cannot load CI utilities.'; exit 1; }
+
+export REGISTRY=${REGISTRY:-quay.io/kubernetes-service-catalog/}
+
+docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
+
+usage() {
+  echo "${0} [-a arch] [-h]"
+  echo ""
+  echo " -a, --arch <arch-name>: Architecture name that should be released, i.e. amd64"
+  echo " -h, --help: Print help"
+}
+
+RELEASE_ARCH=""
+if [[ "$#" -ne 0 ]]; then
+  POSITIONAL=()
+  while [[ $# -gt 0 ]]
+    do
+    key="$1"
+    case ${key} in
+      -b|--arch)
+        RELEASE_ARCH="-${2}"
+        shift # past argument
+        shift # past value
+        ;;
+      -h|--help)
+        usage
+        exit
+        ;;
+      *)    # unknown option
+        POSITIONAL+=("$1") # save it in an array for later
+        shift # past argument
+        ;;
+    esac
+  done
+  set -- ${POSITIONAL[@]+"${POSITIONAL[@]}"}
+fi
+
+
+pushd ${REPO_ROOT_DIR}
+echo ${RELEASE_ARCH}
+if [[ "${TRAVIS_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[a-z]*((-beta.[0-9]+)|(-(r|R)(c|C)[0-9]+))?$ ]]; then
+    shout "Pushing Service Catalog ${RELEASE_ARCH} images with tags '${TRAVIS_TAG}' and 'latest'."
+    TAG_VERSION="${TRAVIS_TAG}" VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make release-push${RELEASE_ARCH}
+elif [[ "${TRAVIS_BRANCH}" == "master" ]]; then
+    shout "Pushing Service Catalog ${RELEASE_ARCH} images with default tags (git sha and 'canary')."
+    make push
+else
+    shout "Skip Service Catalog ${RELEASE_ARCH} deploy"
+fi
+
+popd

--- a/contrib/hack/ci/publish-svcat-cli-release.sh
+++ b/contrib/hack/ci/publish-svcat-cli-release.sh
@@ -30,13 +30,13 @@ docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
 pushd ${REPO_ROOT_DIR}
 
 if [[ "${TRAVIS_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[a-z]*((-beta.[0-9]+)|(-(r|R)(c|C)[0-9]+))?$ ]]; then
-    shout "Pushing images with tags '${TRAVIS_TAG}' and 'latest'."
-    TAG_VERSION="${TRAVIS_TAG}" VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make release-push svcat-publish
+    shout "Pushing svcat CLI images with tags '${TRAVIS_TAG}' and 'latest'."
+    TAG_VERSION="${TRAVIS_TAG}" VERSION="${TRAVIS_TAG}" MUTABLE_TAG="latest" make svcat-publish
 elif [[ "${TRAVIS_BRANCH}" == "master" ]]; then
-    shout "Pushing images with default tags (git sha and 'canary')."
-    make push svcat-publish
+    shout "Pushing svcat CLI images with default tags (git sha and 'canary')."
+    make svcat-publish
 else
-    shout "Nothing to deploy"
+    shout "Skipping svcat CLI deploy"
 fi
 
 popd


### PR DESCRIPTION
**Description**

This PR changes the release process by splitting the single Deploy stage into:
- publish service catalog for amd64 arch
- publish service catalog for arm arch
- publish service catalog for arm64 arch
- publish service catalog for ppc64le arch
- publish service catalog for s390x arch
- publish svcat CLI for win,linux,darwin arch


The Build stages were used: https://docs.travis-ci.com/user/build-stages/#what-are-build-stages
**Related issues:**

- https://github.com/kubernetes-sigs/service-catalog/issues/2726