### PR TITLE
Node selector is a dict

### DIFF
--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -121,5 +121,5 @@ spec:
         {{- end }}
       {{ if .Values.controllerManager.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.controllerManager.nodeSelector | indent(8) }}
+{{ toYaml .Values.controllerManager.nodeSelector | indent 8 }}
       {{ end }}

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -121,5 +121,5 @@ spec:
         {{- end }}
       {{ if .Values.controllerManager.nodeSelector }}
       nodeSelector:
-         {{ .Values.controllerManager.nodeSelector }}
+{{ toYaml .Values.controllerManager.nodeSelector | indent(8) }}
       {{ end }}

--- a/charts/catalog/templates/webhook-deployment.yaml
+++ b/charts/catalog/templates/webhook-deployment.yaml
@@ -83,7 +83,7 @@ spec:
         {{- end }}
       {{ if .Values.webhook.nodeSelector }}
       nodeSelector:
-          {{ .Values.webhook.nodeSelector }}
+{{ toYaml .Values.controllerManager.nodeSelector | indent(8) }}
       {{ end }}
       volumes:
       - name: service-catalog-webhook-cert

--- a/charts/catalog/templates/webhook-deployment.yaml
+++ b/charts/catalog/templates/webhook-deployment.yaml
@@ -83,7 +83,7 @@ spec:
         {{- end }}
       {{ if .Values.webhook.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.controllerManager.nodeSelector | indent(8) }}
+{{ toYaml .Values.webhook.nodeSelector | indent 8 }}
       {{ end }}
       volumes:
       - name: service-catalog-webhook-cert


### PR DESCRIPTION
This PR is a 
 - [X] Feature Implementation
 - [X] Bug Fix

**What this PR does / why we need it**:
The `nodeSelector` parameters in the Helm chart are forced 'this: is not a string' 
This PR makes it dicts, improving usability and consistency

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
