### PR TITLE
Fix ServiceInstance restore process in migration job

### DIFF
--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -288,11 +288,10 @@ func (m *Service) Restore(res *ServiceCatalogResources) error {
 
 	klog.Infof("Applying %d service instances", len(res.serviceInstances))
 	for _, si := range res.serviceInstances {
+		instance := si.DeepCopy()
 		err := RetryOnError(retry.DefaultRetry, func() error {
 			si.RecalculatePrinterColumnStatusFields()
 			si.ResourceVersion = ""
-
-			instance := si.DeepCopy()
 
 			// ServiceInstance must not have class/plan refs when it is created
 			// These fields must be filled using an update


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-sigs/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-sigs/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
This short PR fixes the migration process between a version with APIserver and the crds. 
During the restore process for ServiceInstance, before creating the resource from the backup data, all information about ClusterServiceClass reference is removed. This information is restored in the update process after creation.
If the creation process fails, then we lose information about ClusterServiceClass reference (before the process the data is overwritten with an empty value). This PR fixes this issue.

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
