### PR TITLE
Bump Service Catalog release to 0.3.0-beta.2

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -40,7 +40,7 @@ chart and their default values.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | Service catalog image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-beta.1` |
+| `image` | Service catalog image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-beta.2` |
 | `imagePullPolicy` | `imagePullPolicy` for the service catalog | `Always` |
 | `imagePullSecrets`|  The pre-existing secrets to use to pull images from a private registry | `[]` | 
 | `webhook.updateStrategy` | `updateStrategy` for the service catalog webhook deployment | `RollingUpdate` |

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Service Catalog
 # service-catalog image to use
-image: quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-beta.1
+image: quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-beta.2
 # imagePullSecrets pre-existing secrets to use to pull images from a private registry
 imagePullSecrets: []
 # imagePullPolicy for the service-catalog; valid values are "IfNotPresent",

--- a/charts/healthcheck/values.yaml
+++ b/charts/healthcheck/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Health Check
 # Image to use
-image: quay.io/kubernetes-service-catalog/healthcheck:v0.3.0-beta.1
+image: quay.io/kubernetes-service-catalog/healthcheck:v0.3.0-beta.2
 # imagePullSecrets pre-existing secrets to use to pull images from a private registry
 imagePullSecrets: []
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"

--- a/charts/test-broker/README.md
+++ b/charts/test-broker/README.md
@@ -54,7 +54,7 @@ Service Broker
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | Image to use | `quay.io/kubernetes-service-catalog/test-broker:v0.3.0-beta.1` |
+| `image` | Image to use | `quay.io/kubernetes-service-catalog/test-broker:v0.3.0-beta.2` |
 | `imagePullSecrets`|  The pre-existing secrets to use to pull images from a private registry | `[]` |
 | `imagePullPolicy` | `imagePullPolicy` for the test-broker | `Always` |
 

--- a/charts/test-broker/values.yaml
+++ b/charts/test-broker/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Test Service Broker
 # Image to use
-image: quay.io/kubernetes-service-catalog/test-broker:v0.3.0-beta.1
+image: quay.io/kubernetes-service-catalog/test-broker:v0.3.0-beta.2
 # imagePullSecrets pre-existing secrets to use to pull images from a private registry
 imagePullSecrets: []
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"

--- a/charts/ups-broker/README.md
+++ b/charts/ups-broker/README.md
@@ -34,7 +34,7 @@ Service Broker
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | Image to use | `quay.io/kubernetes-service-catalog/user-broker:v0.3.0-beta.1` |
+| `image` | Image to use | `quay.io/kubernetes-service-catalog/user-broker:v0.3.0-beta.2` |
 | `imagePullSecrets`|  The pre-existing secrets to use to pull images from a private registry | `[]` |
 | `imagePullPolicy` | `imagePullPolicy` for the ups-broker | `Always` |
 

--- a/charts/ups-broker/values.yaml
+++ b/charts/ups-broker/values.yaml
@@ -1,6 +1,6 @@
 # Default values for User-Provided Service Broker
 # Image to use
-image: quay.io/kubernetes-service-catalog/user-broker:v0.3.0-beta.1
+image: quay.io/kubernetes-service-catalog/user-broker:v0.3.0-beta.2
 # imagePullSecrets pre-existing secrets to use to pull images from a private registry
 imagePullSecrets: []
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"


### PR DESCRIPTION
## Release notes:

🚨Service Catalog v0.3.0-beta.2 is now available! 

To install the Service Catalog from this release, run:
```
helm install svc-cat/catalog —version 0.3.0-beta.2
```
In this third beta release for the Service Catalog 0.3.0 milestone, we have worked on the following:

- Fix the problem when the (Cluster)ServiceBroker name longer than 63 characters was not accepted.
- Fix the problem when the (Cluster)ServicePlan name with "_" at the beginning was not accepted.
- Update Deployments in Helm chart to support Kubernetes 1.16.x. More info [here](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/).
- Add retries to migration process in the case of restoring Service Catalog objects.

**Check [beta.0](https://github.com/kubernetes-sigs/service-catalog/releases/tag/v0.3.0-beta.0) and [beta.1](https://github.com/kubernetes-sigs/service-catalog/releases/tag/v0.3.0-beta.1) for more release notes.**

_We'd really appreciate any feedback on the upgrade procedure and any issues or tips you may run into._

# Changes since [beta.1](https://github.com/kubernetes-sigs/service-catalog/releases/tag/v0.3.0-beta.1)
Node selector is a dict (#2733)
Changing Class and Plans labels to sha224 (#2741)
fix golint errors (#2737)
Fix ServiceInstance restore process in migration job (#2735)
cleanup codebase and run gofmt (#2729)
Improve data migration process (restore crds) (#2730)
Improve travis build - skip redundant jobs (#2731)
Change Deployment api to apps/v1 (#2728)
Dump cluster info in case of failed migration and e2e tests (#2723)

# SVCat Binaries
macOS: https://download.svcat.sh/cli/v0.3.0-beta.2/darwin/amd64/svcat
Windows: https://download.svcat.sh/cli/v0.3.0-beta.2/windows/amd64/svcat.exe
Linux: https://download.svcat.sh/cli/v0.3.0-beta.2/linux/amd64/svcat
