### PR TITLE
Bump Service Catalog release to 0.3.0-beta.2 in Helm Charts

### DIFF
--- a/charts/catalog/Chart.yaml
+++ b/charts/catalog/Chart.yaml
@@ -1,3 +1,3 @@
 name: catalog
 description: service-catalog webhook server and controller-manager helm chart
-version: 0.3.0-beta.1
+version: 0.3.0-beta.2

--- a/charts/healthcheck/Chart.yaml
+++ b/charts/healthcheck/Chart.yaml
@@ -1,3 +1,3 @@
 name: healthcheck
 description: HealthCheck monitors the health of Service Catalog
-version: 0.3.0-beta.1
+version: 0.3.0-beta.2

--- a/charts/test-broker/Chart.yaml
+++ b/charts/test-broker/Chart.yaml
@@ -1,3 +1,3 @@
 name: test-broker
 description: test service-broker deployment Helm chart.
-version: 0.3.0-beta.1
+version: 0.3.0-beta.2

--- a/charts/ups-broker/Chart.yaml
+++ b/charts/ups-broker/Chart.yaml
@@ -1,3 +1,3 @@
 name: ups-broker
 description: user-provided service-broker deployment Helm chart.
-version: 0.3.0-beta.1
+version: 0.3.0-beta.2


### PR DESCRIPTION
**Description**

This bumps the Chart versions which were not updated here: https://github.com/kubernetes-sigs/service-catalog/pull/2744