### PR TITLE
Change Deployment api to apps/v1 in cleaner

### DIFF
--- a/charts/catalog/templates/cleaner-job.yaml
+++ b/charts/catalog/templates/cleaner-job.yaml
@@ -78,7 +78,6 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   backoffLimit: 3
-  activeDeadlineSeconds: 100
   template:
     metadata:
       labels:

--- a/charts/catalog/templates/migration-job.yaml
+++ b/charts/catalog/templates/migration-job.yaml
@@ -103,7 +103,6 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   backoffLimit: 1
-  activeDeadlineSeconds: 140
   template:
     metadata:
       labels:

--- a/charts/catalog/templates/pre-migration-job.yaml
+++ b/charts/catalog/templates/pre-migration-job.yaml
@@ -110,7 +110,6 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   backoffLimit: 1
-  activeDeadlineSeconds: 120
   template:
     metadata:
       labels:

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -87,7 +87,7 @@ func (c *Cleaner) RemoveCRDs(releaseNamespace, controllerManagerName string, web
 
 func (c *Cleaner) scaleDownController(namespace, controllerName string) error {
 	klog.V(4).Infof("Fetching deployment %s/%s", namespace, controllerName)
-	deployment, err := c.client.AppsV1beta1().Deployments(namespace).Get(controllerName, v1.GetOptions{})
+	deployment, err := c.client.AppsV1().Deployments(namespace).Get(controllerName, v1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("cannot get deployment %s/%s: %s", namespace, controllerName, err)
 	}
@@ -96,14 +96,14 @@ func (c *Cleaner) scaleDownController(namespace, controllerName string) error {
 	replicas := int32(0)
 	deploymentCopy := deployment.DeepCopy()
 	deploymentCopy.Spec.Replicas = &replicas
-	_, err = c.client.AppsV1beta1().Deployments(deploymentCopy.Namespace).Update(deploymentCopy)
+	_, err = c.client.AppsV1().Deployments(deploymentCopy.Namespace).Update(deploymentCopy)
 	if err != nil {
 		return fmt.Errorf("failed to update deployment %s/%s: %v", namespace, controllerName, err)
 	}
 
 	err = wait.Poll(3*time.Second, 120*time.Second, func() (done bool, err error) {
 		klog.V(4).Info("Waiting for deployment scales down...")
-		deployment, err := c.client.AppsV1beta1().Deployments(namespace).Get(controllerName, v1.GetOptions{})
+		deployment, err := c.client.AppsV1().Deployments(namespace).Get(controllerName, v1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/pkg/cleaner/cleaner_test.go
+++ b/pkg/cleaner/cleaner_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kubernetes-sigs/service-catalog/pkg/probe"
 	"github.com/stretchr/testify/assert"
 	admv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/api/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,7 +55,7 @@ func TestCleaner_RemoveCRDs(t *testing.T) {
 	assert.Len(t, list.Items, 1)
 	assert.Equal(t, "NotServiceCatalogCRD", list.Items[0].Name)
 
-	deployment, err := fakeClik8s.AppsV1beta1().Deployments(cmNamespace).Get(cmName, v1.GetOptions{})
+	deployment, err := fakeClik8s.AppsV1().Deployments(cmNamespace).Get(cmName, v1.GetOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, int32(0), deployment.Status.Replicas)
 
@@ -69,14 +69,14 @@ func TestCleaner_RemoveCRDs(t *testing.T) {
 	assert.Len(t, vwcList.Items, 1)
 }
 
-func newTestDeployment() *v1beta1.Deployment {
+func newTestDeployment() *appsv1.Deployment {
 	var rep int32 = 1
-	return &v1beta1.Deployment{
+	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
 			Namespace: cmNamespace,
 		},
-		Spec: v1beta1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Replicas: &rep,
 		},
 	}

--- a/test/upgrade/examiner/internal/readiness/readiness.go
+++ b/test/upgrade/examiner/internal/readiness/readiness.go
@@ -83,7 +83,7 @@ func (r *readiness) assertServiceCatalogIsReady() error {
 
 func (r *readiness) assertServiceCatalogAPIServerIsUp() error {
 	return wait.Poll(waitInterval, timeoutInterval, func() (done bool, err error) {
-		deployment, err := r.client.AppsV1beta1().Deployments(r.cfg.ServiceCatalogNamespace).Get(r.cfg.ServiceCatalogAPIServerName, v1.GetOptions{})
+		deployment, err := r.client.AppsV1().Deployments(r.cfg.ServiceCatalogNamespace).Get(r.cfg.ServiceCatalogAPIServerName, v1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -98,7 +98,7 @@ func (r *readiness) assertServiceCatalogAPIServerIsUp() error {
 
 func (r *readiness) assertServiceCatalogControllerIsUp() error {
 	return wait.Poll(waitInterval, timeoutInterval, func() (done bool, err error) {
-		deployment, err := r.client.AppsV1beta1().Deployments(r.cfg.ServiceCatalogNamespace).Get(r.cfg.ServiceCatalogControllerServerName, v1.GetOptions{})
+		deployment, err := r.client.AppsV1().Deployments(r.cfg.ServiceCatalogNamespace).Get(r.cfg.ServiceCatalogControllerServerName, v1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -123,7 +123,7 @@ func (r *readiness) assertTestBrokerIsReady() error {
 
 func (r *readiness) assertTestBrokerIsUp() error {
 	return wait.Poll(waitInterval, timeoutInterval, func() (done bool, err error) {
-		deployment, err := r.client.AppsV1beta1().Deployments(r.cfg.TestBrokerNamespace).Get(r.cfg.TestBrokerName, v1.GetOptions{})
+		deployment, err := r.client.AppsV1().Deployments(r.cfg.TestBrokerNamespace).Get(r.cfg.TestBrokerName, v1.GetOptions{})
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
- Deployment.extensions/v1beta1 depricated from k82 1.16
- Remove activeDeadlineSeconds from migration jobs
- The generic timeout from will be applied

Fixes: #2752

 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-sigs/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-sigs/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #2752

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
