### PR TITLE
Fixing error when plan is updated and mutateOnUpdate deletes ClusterServicePlanRef value

### DIFF
--- a/pkg/webhook/servicecatalog/serviceinstance/mutation/handler.go
+++ b/pkg/webhook/servicecatalog/serviceinstance/mutation/handler.go
@@ -156,7 +156,9 @@ func (h *CreateUpdateHandler) syncLabels(obj *sc.ServiceInstance) {
 
 	if obj.Spec.ClusterServiceClassRef != nil {
 		obj.Labels[sc.GroupName+"/"+sc.FilterSpecClusterServiceClassRefName] = util.GenerateSHA(obj.Spec.ClusterServiceClassRef.Name)
-		obj.Labels[sc.GroupName+"/"+sc.FilterSpecClusterServicePlanRefName] = util.GenerateSHA(obj.Spec.ClusterServicePlanRef.Name)
+		if obj.Spec.ClusterServicePlanRef != nil {
+			obj.Labels[sc.GroupName+"/"+sc.FilterSpecClusterServicePlanRefName] = util.GenerateSHA(obj.Spec.ClusterServicePlanRef.Name)
+		}
 	}
 	if obj.Spec.ServiceClassRef != nil {
 		obj.Labels[sc.GroupName+"/"+sc.FilterSpecServiceClassRefName] = util.GenerateSHA(obj.Spec.ServiceClassRef.Name)


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-sigs/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-sigs/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [X] Bug Fix

**What this PR does / why we need it**:
When plan is updated for a service instance, there is a clean up of ClusterServicePlanRef for the new serviceInstance object at function mutateOnUpdate:
https://github.com/kubernetes-sigs/service-catalog/blob/b5a5c4bdb6f4bcf13171476113467feb274de1f7/pkg/webhook/servicecatalog/serviceinstance/mutation/handler.go#L137

Having this ClusterServicePlanRef nil, will make syncLabels function fail.

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
