### PR TITLE
add a trigger for false status ServiceBinding at the end of SI reconc…

### DIFF
--- a/pkg/controller/case_test.go
+++ b/pkg/controller/case_test.go
@@ -561,10 +561,11 @@ func (ct *controllerTest) Deprovision() error {
 func (ct *controllerTest) CreateBinding() error {
 	_, err := ct.scInterface.ServiceBindings(testNamespace).Create(&v1beta1.ServiceBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:  testNamespace,
-			Name:       testBindingName,
-			Generation: 1,
-			Finalizers: []string{v1beta1.FinalizerServiceCatalog}, // set by the Webhook
+			Namespace:   testNamespace,
+			Name:        testBindingName,
+			Generation:  1,
+			Finalizers:  []string{v1beta1.FinalizerServiceCatalog}, // set by the Webhook
+			Annotations: map[string]string{},
 		},
 		Spec: v1beta1.ServiceBindingSpec{
 			InstanceRef: v1beta1.LocalObjectReference{
@@ -1751,10 +1752,11 @@ func (ct *controllerTest) CreateBindingWithParams(params map[string]interface{},
 	}
 	_, err := ct.scInterface.ServiceBindings(testNamespace).Create(&v1beta1.ServiceBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:  testNamespace,
-			Name:       testBindingName,
-			Generation: 1,
-			Finalizers: []string{v1beta1.FinalizerServiceCatalog}, // set by the Webhook
+			Namespace:   testNamespace,
+			Name:        testBindingName,
+			Generation:  1,
+			Finalizers:  []string{v1beta1.FinalizerServiceCatalog}, // set by the Webhook
+			Annotations: map[string]string{},
 		},
 		Spec: v1beta1.ServiceBindingSpec{
 			InstanceRef: v1beta1.LocalObjectReference{
@@ -1779,10 +1781,11 @@ func (ct *controllerTest) AssertBindingData(t *testing.T, expectedData map[strin
 func (ct *controllerTest) CreateBindingWithTransforms(transforms []v1beta1.SecretTransform) error {
 	_, err := ct.scInterface.ServiceBindings(testNamespace).Create(&v1beta1.ServiceBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:  testNamespace,
-			Name:       testBindingName,
-			Generation: 1,
-			Finalizers: []string{v1beta1.FinalizerServiceCatalog}, // set by the Webhook
+			Namespace:   testNamespace,
+			Name:        testBindingName,
+			Generation:  1,
+			Finalizers:  []string{v1beta1.FinalizerServiceCatalog}, // set by the Webhook
+			Annotations: map[string]string{},
 		},
 		Spec: v1beta1.ServiceBindingSpec{
 			InstanceRef: v1beta1.LocalObjectReference{

--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -140,6 +140,16 @@ func isServiceBindingFailed(binding *v1beta1.ServiceBinding) bool {
 	return false
 }
 
+// isServiceBindingSucceeded checks if binding has ready/true conditions
+func (c *controller) isServiceBindingSucceeded(binding *v1beta1.ServiceBinding) bool {
+	for _, condition := range binding.Status.Conditions {
+		if condition.Type == v1beta1.ServiceBindingConditionReady && condition.Status == v1beta1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
 // getReconciliationActionForServiceBinding gets the action the reconciler
 // should be taking on the given binding.
 func getReconciliationActionForServiceBinding(binding *v1beta1.ServiceBinding) ReconciliationAction {

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -2991,8 +2991,8 @@ func (c *controller) handleServiceInstancePollingError(instance *v1beta1.Service
 	return c.continuePollingServiceInstance(instance)
 }
 
-// triggerServiceBindingReconciliation adds an annotation to each ServiceBindings, with false status conditions
-// which belong to succeeded ServiceInstance for reconciling them again
+// triggerServiceBindingReconciliation adds an annotation to every ServiceBinding
+// whose ServiceInstance finishes with success.
 func (c *controller) triggerServiceBindingReconciliation(instance *v1beta1.ServiceInstance) {
 	bindings, err := c.listExistingBindings(instance)
 	if err != nil {
@@ -3004,6 +3004,7 @@ func (c *controller) triggerServiceBindingReconciliation(instance *v1beta1.Servi
 		if c.isServiceBindingSucceeded(binding) {
 			continue
 		}
+		klog.V(4).Infof("ServiceBinding %s/%s triggered to reconciliation", binding.Namespace, binding.Name)
 		toUpdate := binding.DeepCopy()
 		toUpdate.ObjectMeta.Annotations["reconciliationTriggered"] = metav1.Now().String()
 		if _, err := c.serviceCatalogClient.ServiceBindings(toUpdate.Namespace).Update(toUpdate); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-sigs/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-sigs/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
There are situations when Service Instance and Service Binding are applying at the same time (used e.g. in automation scripts). In those cases usually, ServiceBinding will end with `fail` status because of a lack of ServiceInstance.
ServiceBinding will be reconciled again because of re-sync of the informer, the default value is set to 5 min, but if the user sets the `resyncInterval` value higher, then re-reconcilation will be made later.
The solution is to trigger each ServiceBinding with `failed` status to re-reconciliation if ServiceInstance belonging to this SB will end with success.
This PR introduces such a change.

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
