### PR TITLE
Update devguide.md

### DIFF
--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -41,7 +41,7 @@ document.
 
 At a minimum you will need:
 
-* [Docker](https://www.docker.com) 17.05+ installed locally
+* [Docker](https://www.docker.com) 17.05+ installed locally (configured with 4+ GB RAM)
 * GNU Make
 * [git](https://git-scm.com)
 


### PR DESCRIPTION
Docker desktop assigns 2GB RAM for the machine by default. This isn't quite enough to successfully run `make test`.
I noticed the tests started to hang due to lack of memory.

4GB seems to be enough to run all the tests successfully.

This PR is a 
 - [ ] Feature Implementation
 - [ ] Bug Fix
 - [x] Documentation