### PR TITLE
Do not build binaries for test-unit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ check-go:
 test-unit-native: check-go
 	go test $(addprefix ${SC_PKG}/,${TEST_DIRS})
 
-test-unit: .init build
+test-unit: .init .generate_files
 	@echo Running tests:
 	$(DOCKER_CMD) go test -race $(UNIT_TEST_FLAGS) \
 	  $(addprefix $(SC_PKG)/,$(TEST_DIRS)) $(UNIT_TEST_LOG_FLAGS)


### PR DESCRIPTION
Speed up `make test-unit` by no longer building binaries. 

Before:
```
→ time make test-unit
...
real    6m45.337s
user    0m0.559s
sys     0m0.864s
```

After:
```
→ time make test-unit
...
real    1m47.899s
user    0m0.257s
sys     0m0.318s
```
