### PR TITLE
Fix `make verify`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ STAT           = stat -c '%Y %n'
 endif
 
 TYPES_FILES    = $(shell find pkg/apis -name types.go)
-GO_VERSION    ?= 1.12
+GO_VERSION    ?= 1.13
 
 ALL_ARCH=amd64 arm arm64 ppc64le s390x
 ALL_CLIENT_PLATFORM=darwin linux windows
@@ -225,7 +225,7 @@ verify: .init verify-generated verify-client-gen verify-docs verify-vendor
 	@#
 	$(DOCKER_CMD) go vet $(SC_PKG)/...
 	@echo Running repo-infra verify scripts
-	@$(DOCKER_CMD) vendor/github.com/kubernetes/repo-infra/verify/verify-boilerplate.sh --rootdir=. | grep -Fv -e generated -e .pkg -e docsite > .out 2>&1 || true
+	@$(DOCKER_CMD) vendor/github.com/kubernetes/repo-infra/verify/verify-boilerplate.sh --rootdir=. | grep -Fv -e generated -e .pkg -e docsite -e bin/verify-links.sh > .out 2>&1 || true
 	@[ ! -s .out ] || (cat .out && rm .out && false)
 	@rm .out
 	@#
@@ -238,7 +238,7 @@ verify: .init verify-generated verify-client-gen verify-docs verify-vendor
 
 verify-docs: .init
 	@echo Running href checker$(SKIP_COMMENT):
-	@$(DOCKER_CMD) verify-links.sh -s .pkg -s .bundler -s _plugins -s _includes -t $(SKIP_HTTP) .
+	@$(DOCKER_CMD) verify-links.sh -s .pkg -s .bundler -s _plugins -s _includes -s contribute/docs.md -t $(SKIP_HTTP) .
 
 verify-generated: .init generators
 	$(DOCKER_CMD) $(BUILD_DIR)/update-apis-gen.sh --verify-only

--- a/pkg/kubernetes/README.md
+++ b/pkg/kubernetes/README.md
@@ -24,6 +24,6 @@ in sync.
 ## Long-term plan
 
 In the long term the packages used by Kubernetes-based projects will be moved
-from the main repo to separate top-level repositories, [k8s.io/common](https://github.com/kubernetes/common)
-and [k8s.io/utils](https://github.com/kubernetes/utils). Once it is done, we can
+from the main repo to separate top-level repositories, k8s.io/common and
+[k8s.io/utils](https://github.com/kubernetes/utils). Once it is done, we can
 eventually switch to those packages and drop this directory.


### PR DESCRIPTION
A few things are causing the `make verify` command (and subsequently `make`) to
fail. These are addressed in this commit, as follows:

1. `make verify-docs` - Explicitely skip the localhost link in
contribute/docs.md and remove a link for a non-yet-existent repository in
pkg/kubernetes/README.md.
1. Exclude `bin/verify-links.sh` from the `verify-boilerplate.sh` check (this
file is .gitignored)
1. Update `GO_VERSION` defined in the Makefile to match `GO_VERSION` defined in
.travis.yml

These changes allow a developer to clone the repo, cd into it and run `make` and have it pass successfully.
Addresses an issue mentioned in #2782.

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [x] Documentation

---

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
