### PR TITLE
Update ups-broker docs link to point to chart on github.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,7 +30,7 @@ when running in plugin mode, so instead of using `--flag` you must specify a val
 Run `svcat --help` to see the available commands.
 
 Below are some common tasks made easy with svcat. The example output assumes that the
-[User Provided Service Broker](../charts/ups-broker) is installed on the cluster.
+[User Provided Service Broker](https://github.com/kubernetes-sigs/service-catalog/tree/master/charts/ups-broker) is installed on the cluster.
 
 ## Register a broker
 ```console 


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-sigs/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-sigs/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [X] Bug Fix
 - [X] Documentation

**What this PR does / why we need it**:
Fixes a broken link in the docs to the ups-broker helm chart. The existing version of the links points to the correct location in the git repository, but is incorrect when rendered into the web version of the docs. I have instead made the link point to the chart on GitHub. If there is a better option for pointing to the correct helm chart, I'm open to suggestions.

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #2757

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
