### PR TITLE
Fix ServicePlan resync

### DIFF
--- a/pkg/controller/controller_serviceplan.go
+++ b/pkg/controller/controller_serviceplan.go
@@ -62,7 +62,7 @@ func (c *controller) reconcileServicePlanKey(key string) error {
 		return err
 	}
 	pcb := pretty.NewContextBuilder(pretty.ServicePlan, namespace, name, "")
-	plan, err := c.servicePlanLister.ServicePlans(namespace).Get(key)
+	plan, err := c.servicePlanLister.ServicePlans(namespace).Get(name)
 	if errors.IsNotFound(err) {
 		klog.Infof(pcb.Message("not doing work because plan has been deleted"))
 		return nil

--- a/pkg/controller/controller_serviceplan_test.go
+++ b/pkg/controller/controller_serviceplan_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"errors"
+	"k8s.io/client-go/tools/cache"
 	"testing"
 
 	"github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
@@ -116,7 +117,7 @@ func TestReconcileServicePlanRemovedFromCatalog(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, fakeCatalogClient, _, testController, _ := newTestController(t, noFakeActions())
+			_, fakeCatalogClient, _, testController, sharedInformers := newTestController(t, noFakeActions())
 
 			fakeCatalogClient.AddReactor("list", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
 				return true, &v1beta1.ServiceInstanceList{Items: tc.instances}, nil
@@ -126,7 +127,15 @@ func TestReconcileServicePlanRemovedFromCatalog(t *testing.T) {
 				tc.catalogClientPrepFunc(fakeCatalogClient)
 			}
 
-			err := reconcileServicePlan(t, testController, tc.plan)
+			err := sharedInformers.ServicePlans().Informer().GetStore().Add(tc.plan)
+			if err != nil {
+				t.Fatalf("unexpected error while creating test service plan: %v", err)
+			}
+			if testController.servicePlanLister == nil {
+				testController.servicePlanLister = sharedInformers.ServicePlans().Lister()
+			}
+
+			err = reconcileServicePlanKey(t, testController, tc.plan)
 			if err != nil {
 				if !tc.shouldError {
 					t.Fatalf("unexpected error from method under test: %v", err)
@@ -146,11 +155,16 @@ func TestReconcileServicePlanRemovedFromCatalog(t *testing.T) {
 	}
 }
 
-func reconcileServicePlan(t *testing.T, testController *controller, servicePlan *v1beta1.ServicePlan) error {
+func reconcileServicePlanKey(t *testing.T, testController *controller, servicePlan *v1beta1.ServicePlan) error {
 	clone := servicePlan.DeepCopy()
-	err := testController.reconcileServicePlan(servicePlan)
+	key, err := cache.MetaNamespaceKeyFunc(servicePlan)
+	if err != nil {
+		t.Fatalf("unexpected error while buidling service plan key: %v", err)
+	}
+
+	err = testController.reconcileServicePlanKey(key)
 	if !reflect.DeepEqual(servicePlan, clone) {
-		t.Errorf("reconcileServicePlan shouldn't mutate input, but it does: %s", expectedGot(clone, servicePlan))
+		t.Errorf("reconcileServicePlanKey shouldn't mutate input, but it does: %s", expectedGot(clone, servicePlan))
 	}
 	return err
 }

--- a/pkg/controller/controller_serviceplan_test.go
+++ b/pkg/controller/controller_serviceplan_test.go
@@ -18,16 +18,15 @@ package controller
 
 import (
 	"errors"
-	"k8s.io/client-go/tools/cache"
 	"testing"
+	"reflect"
 
 	"github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-sigs/service-catalog/pkg/util"
 	"github.com/kubernetes-sigs/service-catalog/test/fake"
+
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	"reflect"
-
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	clientgotesting "k8s.io/client-go/testing"

--- a/pkg/controller/controller_serviceplan_test.go
+++ b/pkg/controller/controller_serviceplan_test.go
@@ -18,18 +18,18 @@ package controller
 
 import (
 	"errors"
-	"testing"
 	"reflect"
+	"testing"
 
 	"github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	"github.com/kubernetes-sigs/service-catalog/pkg/util"
 	"github.com/kubernetes-sigs/service-catalog/test/fake"
 
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
 )
 
 func TestReconcileServicePlanRemovedFromCatalog(t *testing.T) {


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-sigs/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-sigs/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

This PR fixes a situation when some ServicePlan was marked as `removedFromBrokerCatalog` and it wasn't removed on ServicePlan reconcile. The removing logic was blocked due to a bug, which I'm trying to address in this PR.


Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
