### PR TITLE
Change deprecated Deployment version

### DIFF
--- a/charts/catalog-v0.2/templates/apiserver-deployment.yaml
+++ b/charts/catalog-v0.2/templates/apiserver-deployment.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "fullname" . }}-apiserver
   labels:

--- a/charts/catalog-v0.2/templates/controller-manager-deployment.yaml
+++ b/charts/catalog-v0.2/templates/controller-manager-deployment.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "fullname" . }}-controller-manager
   labels:

--- a/charts/test-broker/templates/broker-deployment.yaml
+++ b/charts/test-broker/templates/broker-deployment.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "fullname" . }}
   labels:

--- a/charts/ups-broker/templates/broker-deployment.yaml
+++ b/charts/ups-broker/templates/broker-deployment.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "fullname" . }}
   labels:


### PR DESCRIPTION
**Description**

- Change deprecated Deployment version

It's necessary as we want to use the newest k8s in our migration job but right now it's failing:

```
#################################################################################################
# Mon May 18 18:11:47 UTC 2020
# - Installing Service Catalog in version 0.2.x
#################################################################################################

"svc-cat" has been added to your repositories
Error: validation failed: unable to recognize "": no matches for kind "Deployment" in version "extensions/v1beta1"
```

https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_service-catalog/2803/pull-service-catalog-test-migration/1262445299377377280