### PR TITLE
Update version from 0.2.2 to 0.2.3

### DIFF
--- a/charts/catalog-v0.2/Chart.yaml
+++ b/charts/catalog-v0.2/Chart.yaml
@@ -1,3 +1,3 @@
 name: catalog-v0.2
 description: service-catalog API server and controller-manager helm chart
-version: 0.2.2
+version: 0.2.3

--- a/charts/catalog-v0.2/README.md
+++ b/charts/catalog-v0.2/README.md
@@ -40,7 +40,7 @@ chart and their default values.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | apiserver image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.2.2` |
+| `image` | apiserver image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.2.3` |
 | `imagePullPolicy` | `imagePullPolicy` for the service catalog | `Always` |
 | `apiserver.replicas` | `replicas` for the service catalog apiserver pod count | `1` |
 | `apiserver.updateStrategy` | `updateStrategy` for the service catalog apiserver deployments | `RollingUpdate` |

--- a/charts/catalog-v0.2/values.yaml
+++ b/charts/catalog-v0.2/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Service Catalog
 # service-catalog image to use
-image: quay.io/kubernetes-service-catalog/service-catalog:v0.2.2
+image: quay.io/kubernetes-service-catalog/service-catalog:v0.2.3
 # imagePullPolicy for the service-catalog; valid values are "IfNotPresent",
 # "Never", and "Always"
 imagePullPolicy: Always

--- a/charts/healthcheck/Chart.yaml
+++ b/charts/healthcheck/Chart.yaml
@@ -1,3 +1,3 @@
 name: healthcheck
 description: HealthCheck monitors the health of Service Catalog
-version: 0.2.1
+version: 0.2.3

--- a/charts/healthcheck/values.yaml
+++ b/charts/healthcheck/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Health Check
 # Image to use
-image: quay.io/kubernetes-service-catalog/healthcheck:v0.2.1
+image: quay.io/kubernetes-service-catalog/healthcheck:v0.2.3
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: IfNotPresent
 rbacApiVersion: rbac.authorization.k8s.io/v1

--- a/charts/test-broker/Chart.yaml
+++ b/charts/test-broker/Chart.yaml
@@ -1,3 +1,3 @@
 name: test-broker
 description: test service-broker deployment Helm chart.
-version: 0.2.1
+version: 0.2.3

--- a/charts/test-broker/README.md
+++ b/charts/test-broker/README.md
@@ -54,7 +54,7 @@ Service Broker
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | Image to use | `quay.io/kubernetes-service-catalog/test-broker:v0.2.1` |
+| `image` | Image to use | `quay.io/kubernetes-service-catalog/test-broker:v0.2.3` |
 | `imagePullPolicy` | `imagePullPolicy` for the test-broker | `Always` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to

--- a/charts/test-broker/values.yaml
+++ b/charts/test-broker/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Test Service Broker
 # Image to use
-image: quay.io/kubernetes-service-catalog/test-broker:v0.2.1
+image: quay.io/kubernetes-service-catalog/test-broker:v0.2.3
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: Always
 # Whether the broker should also log to stderr instead of to files only

--- a/charts/ups-broker/Chart.yaml
+++ b/charts/ups-broker/Chart.yaml
@@ -1,3 +1,3 @@
 name: ups-broker
 description: user-provided service-broker deployment Helm chart.
-version: 0.2.1
+version: 0.2.3

--- a/charts/ups-broker/README.md
+++ b/charts/ups-broker/README.md
@@ -34,7 +34,7 @@ Service Broker
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | Image to use | `quay.io/kubernetes-service-catalog/user-broker:v0.2.1` |
+| `image` | Image to use | `quay.io/kubernetes-service-catalog/user-broker:v0.2.3` |
 | `imagePullPolicy` | `imagePullPolicy` for the ups-broker | `Always` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to

--- a/charts/ups-broker/values.yaml
+++ b/charts/ups-broker/values.yaml
@@ -1,6 +1,6 @@
 # Default values for User-Provided Service Broker
 # Image to use
-image: quay.io/kubernetes-service-catalog/user-broker:v0.2.1
+image: quay.io/kubernetes-service-catalog/user-broker:v0.2.3
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: Always
 # Whether the broker should also log to stderr instead of to files only


### PR DESCRIPTION
**Description**

- Update version from 0.2.2 to 0.2.3

## Changelog

```
# Changes
* Fix helm chart name (#2697)
* Bump bundler version for jekyll and set fix version for jekyll (#2794) 
* update generated files to pickup 2020 copyright (#2794)
* Change deprecated Deployment version (#2794)
* Update version from 0.2.2 to 0.2.3 (#2794)

# SVCat Binaries
macOS: https://download.svcat.sh/cli/v0.2.3/darwin/amd64/svcat
Windows: https://download.svcat.sh/cli/v0.2.3/windows/amd64/svcat.exe
Linux: https://download.svcat.sh/cli/v0.2.3/linux/amd64/svcat


> **NOTE:** This is the last release of the API Server-based implementation with features.  Source code is available on the [v0.2 branch](https://github.com/kubernetes-sigs/service-catalog/tree/v0.2). We support this implementation by providing bug fixes until July 2020.
```