### PR TITLE
Update version from 0.3.0-beta.2 to 0.3.0

### DIFF
--- a/charts/catalog/Chart.yaml
+++ b/charts/catalog/Chart.yaml
@@ -1,3 +1,3 @@
 name: catalog
 description: service-catalog webhook server and controller-manager helm chart
-version: 0.3.0-beta.2
+version: 0.3.0

--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -40,7 +40,7 @@ chart and their default values.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | Service catalog image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-beta.2` |
+| `image` | Service catalog image to use | `quay.io/kubernetes-service-catalog/service-catalog:v0.3.0` |
 | `imagePullPolicy` | `imagePullPolicy` for the service catalog | `Always` |
 | `imagePullSecrets`|  The pre-existing secrets to use to pull images from a private registry | `[]` | 
 | `webhook.updateStrategy` | `updateStrategy` for the service catalog webhook deployment | `RollingUpdate` |

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Service Catalog
 # service-catalog image to use
-image: quay.io/kubernetes-service-catalog/service-catalog:v0.3.0-beta.2
+image: quay.io/kubernetes-service-catalog/service-catalog:v0.3.0
 # imagePullSecrets pre-existing secrets to use to pull images from a private registry
 imagePullSecrets: []
 # imagePullPolicy for the service-catalog; valid values are "IfNotPresent",

--- a/charts/healthcheck/Chart.yaml
+++ b/charts/healthcheck/Chart.yaml
@@ -1,3 +1,3 @@
 name: healthcheck
 description: HealthCheck monitors the health of Service Catalog
-version: 0.3.0-beta.2
+version: 0.3.0

--- a/charts/healthcheck/values.yaml
+++ b/charts/healthcheck/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Health Check
 # Image to use
-image: quay.io/kubernetes-service-catalog/healthcheck:v0.3.0-beta.2
+image: quay.io/kubernetes-service-catalog/healthcheck:v0.3.0
 # imagePullSecrets pre-existing secrets to use to pull images from a private registry
 imagePullSecrets: []
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"

--- a/charts/test-broker/Chart.yaml
+++ b/charts/test-broker/Chart.yaml
@@ -1,3 +1,3 @@
 name: test-broker
 description: test service-broker deployment Helm chart.
-version: 0.3.0-beta.2
+version: 0.3.0

--- a/charts/test-broker/README.md
+++ b/charts/test-broker/README.md
@@ -54,7 +54,7 @@ Service Broker
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | Image to use | `quay.io/kubernetes-service-catalog/test-broker:v0.3.0-beta.2` |
+| `image` | Image to use | `quay.io/kubernetes-service-catalog/test-broker:v0.3.0` |
 | `imagePullSecrets`|  The pre-existing secrets to use to pull images from a private registry | `[]` |
 | `imagePullPolicy` | `imagePullPolicy` for the test-broker | `Always` |
 

--- a/charts/test-broker/values.yaml
+++ b/charts/test-broker/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Test Service Broker
 # Image to use
-image: quay.io/kubernetes-service-catalog/test-broker:v0.3.0-beta.2
+image: quay.io/kubernetes-service-catalog/test-broker:v0.3.0
 # imagePullSecrets pre-existing secrets to use to pull images from a private registry
 imagePullSecrets: []
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"

--- a/charts/ups-broker/Chart.yaml
+++ b/charts/ups-broker/Chart.yaml
@@ -1,3 +1,3 @@
 name: ups-broker
 description: user-provided service-broker deployment Helm chart.
-version: 0.3.0-beta.2
+version: 0.3.0

--- a/charts/ups-broker/README.md
+++ b/charts/ups-broker/README.md
@@ -34,7 +34,7 @@ Service Broker
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image` | Image to use | `quay.io/kubernetes-service-catalog/user-broker:v0.3.0-beta.2` |
+| `image` | Image to use | `quay.io/kubernetes-service-catalog/user-broker:v0.3.0` |
 | `imagePullSecrets`|  The pre-existing secrets to use to pull images from a private registry | `[]` |
 | `imagePullPolicy` | `imagePullPolicy` for the ups-broker | `Always` |
 

--- a/charts/ups-broker/values.yaml
+++ b/charts/ups-broker/values.yaml
@@ -1,6 +1,6 @@
 # Default values for User-Provided Service Broker
 # Image to use
-image: quay.io/kubernetes-service-catalog/user-broker:v0.3.0-beta.2
+image: quay.io/kubernetes-service-catalog/user-broker:v0.3.0
 # imagePullSecrets pre-existing secrets to use to pull images from a private registry
 imagePullSecrets: []
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"


### PR DESCRIPTION
 **Description**

- Update version from 0.3.0-beta.2 to 0.3.0


## Release notes:

🚨Service Catalog v0.3.0 is now available! 

This is a **MAJOR** release. In 0.3.0 release, we've focused on replacing the Aggregated API Server with the CustomResourceDefinitions (CRDs) and Admission Webhook solution. The [Service Catalog documentation](https://svc-cat.io) is updated. Check it out for more details.

To install the Service Catalog from this release, run:
```
helm install svc-cat/catalog \
    --name catalog --namespace catalog --version 0.3.0
```

If you have installed Service Catalog on your cluster using the `helm install svc-cat/catalog` command, then migration process is automated for you and you can just run:
```
helm upgrade <release_name> svc-cat/catalog --version 0.3.0
```

The migration process is described [here](https://svc-cat.io/docs/migration-apiserver-to-crds/) in detail. There you will also find information on how to upgrade Service Catalog manually.

_We'd really appreciate any feedback on the upgrade procedure and any issues or tips you may run into._

# Changes since [beta.2](https://github.com/kubernetes-sigs/service-catalog/releases/tag/v0.3.0-beta.2)

**Check [beta.0](https://github.com/kubernetes-sigs/service-catalog/releases/tag/v0.3.0-beta.0), [beta.1](https://github.com/kubernetes-sigs/service-catalog/releases/tag/v0.3.0-beta.1), and [beta.2](https://github.com/kubernetes-sigs/service-catalog/releases/tag/v0.3.0-beta.2) for more release notes.**

# SVCat Binaries
macOS: https://download.svcat.sh/cli/v0.3.0/darwin/amd64/svcat
Windows: https://download.svcat.sh/cli/v0.3.0/windows/amd64/svcat.exe
Linux: https://download.svcat.sh/cli/v0.3.0/linux/amd64/svcat

