### PR TITLE
Add small improvements in catalog chart

### DIFF
--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -47,7 +47,7 @@ chart and their default values.
 | `webhook.minReadySeconds` | how many seconds an webhook server pod needs to be ready before killing the next, during update | `1` |
 | `webhook.annotations` | Annotations for webhook pods | `{}` |
 | `webhook.nodeSelector` | A nodeSelector value to apply to the webhook pods. If not specified, no nodeSelector will be applied | |
-| `webhook.service.type` | Type of service; valid values are `LoadBalancer` , `NodePort` and `ClusterIP` | `NodePort` |
+| `webhook.service.type` | Type of service; valid values are `LoadBalancer` , `NodePort` and `ClusterIP` | `ClusterIP` |
 | `webhook.service.nodePort.securePort` | If service type is `NodePort`, specifies a port in allowable range (e.g. 30000 - 32767 on minikube); The TLS-enabled endpoint will be exposed here | `30443` |
 | `webhook.service.clusterIP` | If service type is ClusterIP, specify clusterIP as `None` for `headless services` OR specify your own specific IP OR leave blank to let Kubernetes assign a cluster IP |  |
 | `webhook.verbosity` | Log level; valid values are in the range 0 - 10 | `10` |

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -9,8 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: {{ .Values.controllerManager.replicas }}
-  strategy:
-    type: {{ .Values.controllerManager.updateStrategy }}
+  strategy: {{ toYaml .Values.controllerManager.strategy | nindent 4 }}
   minReadySeconds: {{ .Values.controllerManager.minReadySeconds }}
   selector:
     matchLabels:

--- a/charts/catalog/templates/controller-manager-service.yaml
+++ b/charts/catalog/templates/controller-manager-service.yaml
@@ -23,4 +23,6 @@ spec:
     targetPort: 8444
     {{- if eq .Values.controllerManager.service.type "NodePort" }}
     nodePort: {{ .Values.controllerManager.service.nodePort.securePort }}
-    {{- end }}
+    {{ else }}
+    nodePort: null
+    {{ end }}

--- a/charts/catalog/templates/webhook-deployment.yaml
+++ b/charts/catalog/templates/webhook-deployment.yaml
@@ -9,8 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
-  strategy:
-    type: {{ .Values.webhook.updateStrategy }}
+  strategy: {{ toYaml .Values.webhook.strategy | nindent 4 }}
   minReadySeconds: {{ .Values.webhook.minReadySeconds }}
   selector:
     matchLabels:

--- a/charts/catalog/templates/webhook-service.yaml
+++ b/charts/catalog/templates/webhook-service.yaml
@@ -23,4 +23,6 @@ spec:
     targetPort: 8443
     {{- if eq .Values.webhook.service.type "NodePort" }}
     nodePort: {{ .Values.webhook.service.nodePort.securePort }}
+    {{ else }}
+    nodePort: null
     {{- end }}

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -11,8 +11,11 @@ imagePullPolicy: Always
 rbacEnable: true
 rbacApiVersion: rbac.authorization.k8s.io/v1
 webhook:
-  # updateStrategy for service-catalog; value values are "RollingUpdate" and "Recreate"
-  updateStrategy: RollingUpdate
+  # deployment strategy for service-catalog webhook
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
   minReadySeconds: 1
   # annotations is a collection of annotations to add to the webhook pods.
   annotations: {}
@@ -23,11 +26,11 @@ webhook:
     enabled: true
   # Attributes of the webhook's service resource
   service:
+    port: 443
     # Type of service; valid values are "LoadBalancer", "NodePort" or "ClusterIP"
     # NodePort is useful if deploying on bare metal or hacking locally on
     # minikube
-    port: 443
-    type: NodePort
+    type: ClusterIP
     # Further configuration for services of type NodePort
     nodePort:
       # Available port in allowable range (e.g. 30000 - 32767 on minikube)
@@ -41,14 +44,17 @@ webhook:
   resources:
     requests:
       cpu: 100m
-      memory: 20Mi
+      memory: 35Mi
     limits:
       cpu: 100m
-      memory: 30Mi
+      memory: 45Mi
 controllerManager:
   replicas: 1
-  # updateStrategy for service-catalog; value values are "RollingUpdate" and "Recreate"
-  updateStrategy: RollingUpdate
+  # deployment strategy for service-catalog controllerManager
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
   minReadySeconds: 1
   # annotations is a collection of annotations to add to the controllerManager pod.
   annotations: {}


### PR DESCRIPTION
**Description**

Add small improvements in catalog chart:
  - better support for update strategy
  - by switching type from `NodePort` to `ClusterIP` we get such error:
      ```
      UPGRADE FAILED
      Error: Service "test-svc" is invalid: spec.ports[0].nodePort: Forbidden: may not be used when `type` is 'ClusterIP'
      Error: UPGRADE FAILED: Service "test-svc" is invalid: spec.ports[0].nodePort: Forbidden: may not be used when `type` is 'ClusterIP'
      ```
      
      to fix that problem we just need to set the **nodePort** to `null` when using `ClusterIP` type

 - use the ClusterIP for webhook Service, as a default one (using NodePort is not a good approach in the released chart) ( we already using that for controller manager so we make that consistent)
