### PR TITLE
fix pb when use securityContext and add opportunity to add storageclass

### DIFF
--- a/charts/catalog/templates/cleaner-job.yaml
+++ b/charts/catalog/templates/cleaner-job.yaml
@@ -87,7 +87,12 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
-      restartPolicy: Never
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
+
+        restartPolicy: Never
       serviceAccountName: clean-job-account
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -35,6 +35,9 @@ spec:
       serviceAccountName: "{{ .Values.controllerManager.serviceAccount }}"
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
+      volumes:
+        - name: run
+          emptyDir: {}
       containers:
       - name: controller-manager
         image: {{ .Values.image }}
@@ -99,6 +102,9 @@ spec:
         - --feature-gates
         - CascadingDeletion=true
         {{- end }}
+        volumeMounts:
+        - mountPath: /var/run
+          name: run
         ports:
         - containerPort: 8444
         {{- if .Values.controllerManager.healthcheck.enabled }}

--- a/charts/catalog/templates/migration-job.yaml
+++ b/charts/catalog/templates/migration-job.yaml
@@ -112,6 +112,10 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
       restartPolicy: Never
       serviceAccountName: migration-job-account
       imagePullSecrets:

--- a/charts/catalog/templates/pre-migration-job.yaml
+++ b/charts/catalog/templates/pre-migration-job.yaml
@@ -92,6 +92,13 @@ spec:
   resources:
     requests:
       storage: 200Mi
+{{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+      storageClassName: ""
+  {{- else }}
+      storageClassName: "{{ .Values.persistence.storageClass }}"
+  {{- end }}
+{{- end }}
 
 ---
 apiVersion: batch/v1
@@ -119,7 +126,12 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
-      restartPolicy: Never
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
+
+        restartPolicy: Never
       serviceAccountName: pre-migration-job-account
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/catalog/templates/webhook-deployment.yaml
+++ b/charts/catalog/templates/webhook-deployment.yaml
@@ -28,6 +28,11 @@ spec:
 {{ toYaml .Values.webhook.annotations | indent 8 }}
       {{- end }}
     spec:
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
+
       serviceAccountName: "{{ .Values.webhook.serviceAccount }}"
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}


### PR DESCRIPTION
This PR is a 
 - [X] Feature Implementation
 - [X] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
-Feature: add the opportunity to use a specific storageClass, it's mandatory when no default storageclass is defined inside a K8S.
Fix pb on securitycontext

**Which issue(s) this PR fixes** 
Fixes #
-Bug fix: If a securityContext is set the process is not able to create directory
```
I0609 12:50:10.145130       1 controller_manager.go:135] Using inClusterConfig to talk to service catalog API server -- make sure your API server is registered with the aggregator
Error: failed to establish SecureServingOptions mkdir /var/run/kubernetes-service-catalog: permission denied
```
To solve it I create an emptyDir volume
The securitycontext is also add for job and webhook


Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
