### PR TITLE
Fix RemoveFinalizer methods in svcat cli

### DIFF
--- a/pkg/svcat/service-catalog/binding.go
+++ b/pkg/svcat/service-catalog/binding.go
@@ -277,7 +277,7 @@ func (sdk *SDK) RemoveFinalizerForBinding(namespacedName types.NamespacedName) e
 	finalizers := sets.NewString(binding.Finalizers...)
 	finalizers.Delete(v1beta1.FinalizerServiceCatalog)
 	binding.Finalizers = finalizers.List()
-	_, err = sdk.ServiceCatalog().ServiceBindings(binding.Namespace).UpdateStatus(context.Background(), binding, v1.UpdateOptions{})
+	_, err = sdk.ServiceCatalog().ServiceBindings(binding.Namespace).Update(context.Background(), binding, v1.UpdateOptions{})
 	return err
 }
 

--- a/pkg/svcat/service-catalog/instance.go
+++ b/pkg/svcat/service-catalog/instance.go
@@ -321,7 +321,7 @@ func (sdk *SDK) RemoveFinalizerForInstance(ns, name string) error {
 	finalizers := sets.NewString(instance.Finalizers...)
 	finalizers.Delete(v1beta1.FinalizerServiceCatalog)
 	instance.Finalizers = finalizers.List()
-	_, err = sdk.ServiceCatalog().ServiceInstances(instance.Namespace).UpdateStatus(context.Background(), instance, v1.UpdateOptions{})
+	_, err = sdk.ServiceCatalog().ServiceInstances(instance.Namespace).Update(context.Background(), instance, v1.UpdateOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description**

Fix method for removing the service-catalog finalizer from the ServiceInstance and ServiceBinding.

**Context:**
In the previous approach (Aggregate API server) the `UpdateStatus` func allowed to update fields under `metadata` entry. When we switch to the native webhook concept, this hacky implementation was removed and now we should use the `Update` function as the `UpdateStatus` modifies only `Status` entry. 


/kind bug