### PR TITLE
Remove Secret listener from controller

### DIFF
--- a/charts/catalog/templates/rbac.yaml
+++ b/charts/catalog/templates/rbac.yaml
@@ -16,7 +16,7 @@ rules:
     # TODO: do not grant global access, limit to particular secrets referenced from servicebindings
     - apiGroups: [""]
       resources: ["secrets"]
-      verbs:     ["get","create","update","delete", "list", "watch"]
+      verbs:     ["get","create","update","delete"]
     - apiGroups: [""]
       resources: ["pods"]
       verbs:     ["get","list","update", "patch", "watch", "delete", "initialize"]

--- a/cmd/controller-manager/app/controller_manager.go
+++ b/cmd/controller-manager/app/controller_manager.go
@@ -59,7 +59,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/client-go/informers"
 	"k8s.io/klog"
 )
 
@@ -303,10 +302,7 @@ func StartControllers(s *options.ControllerManagerServer,
 	if err != nil {
 		klog.Fatal(err)
 	}
-	klog.V(5).Infof("Creating shared informers; resync interval: %v", s.ResyncInterval)
-
-	coreInformerFactory := informers.NewSharedInformerFactory(coreClient, s.ResyncInterval)
-	coreInformers := coreInformerFactory.Core()
+	klog.V(5).Infof("Creating shared informer; resync interval: %v", s.ResyncInterval)
 
 	// Build the informer factory for service-catalog resources
 	informerFactory := servicecataloginformers.NewSharedInformerFactory(
@@ -319,7 +315,6 @@ func StartControllers(s *options.ControllerManagerServer,
 	klog.V(5).Infof("Creating controller; broker relist interval: %v", s.ServiceBrokerRelistInterval)
 	serviceCatalogController, err := controller.NewController(
 		coreClient,
-		coreInformers.V1().Secrets(),
 		serviceCatalogClientBuilder.ClientOrDie(controllerManagerAgentName).ServicecatalogV1beta1(),
 		serviceCatalogSharedInformers.ClusterServiceBrokers(),
 		serviceCatalogSharedInformers.ServiceBrokers(),
@@ -345,11 +340,9 @@ func StartControllers(s *options.ControllerManagerServer,
 
 	klog.V(1).Info("Starting shared informers")
 	informerFactory.Start(stop)
-	coreInformerFactory.Start(stop)
 
 	klog.V(5).Info("Waiting for caches to sync")
 	informerFactory.WaitForCacheSync(stop)
-	coreInformerFactory.WaitForCacheSync(stop)
 
 	klog.V(5).Info("Running controller")
 	go serviceCatalogController.Run(s.ConcurrentSyncs, stop)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -46,7 +46,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/informers"
 	clientgofake "k8s.io/client-go/kubernetes/fake"
 	clientgotesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
@@ -2429,15 +2428,11 @@ func newTestController(t *testing.T, config fakeosb.FakeClientConfiguration) (
 	informerFactory := servicecataloginformers.NewSharedInformerFactory(fakeCatalogClient, 0)
 	serviceCatalogSharedInformers := informerFactory.Servicecatalog().V1beta1()
 
-	k8sInformerFactory := informers.NewSharedInformerFactory(fakeKubeClient, 0)
-	k8sInformers := k8sInformerFactory.Core().V1()
-
 	fakeRecorder := record.NewFakeRecorder(5)
 
 	// create a test controller
 	testController, err := NewController(
 		fakeKubeClient,
-		k8sInformers.Secrets(),
 		fakeCatalogClient.ServicecatalogV1beta1(),
 		serviceCatalogSharedInformers.ClusterServiceBrokers(),
 		serviceCatalogSharedInformers.ServiceBrokers(),


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
This fix removes from controller "core sharedInformer" used for getting secret in the case when ServiceBroker or ClusterServiceBroker use authentication to connect with a broker. 
SharedInformer shortly after start is synchronized, which causes huge memory usage when a lot of secret resources exist in the cluster (which is the norm at helm3 which keeps charts inside secrets).
The collection of resources can be performed directly by the Kubernetes client as it happens `controller_binding` during binding operation.

**Which issue(s) this PR fixes** 
Fixes #2824 

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
