### PR TITLE
Fix mutation defualt plan functionality for ServiceInstance

### DIFF
--- a/pkg/webhook/servicecatalog/serviceinstance/mutation/default_service_plan_test.go
+++ b/pkg/webhook/servicecatalog/serviceinstance/mutation/default_service_plan_test.go
@@ -196,6 +196,22 @@ func TestServiceClassSpecified(t *testing.T) {
 				newServicePlans(className, namespace, 2, true)[1],
 			},
 		},
+		"SuccessWithFindingDefaultPlanForManyServiceClasses": {
+			instance: &sc.ServiceInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "instance", Namespace: "dummy"},
+				Spec: sc.ServiceInstanceSpec{
+					PlanReference: sc.PlanReference{
+						ServiceClassExternalName: className,
+					},
+				},
+			},
+			objects: []runtime.Object{
+				newServiceClass(className, className, namespace),
+				newServiceClass(className, className, "otherNamespace"),
+				newServicePlans(className, namespace, 1, true)[0],
+				newServicePlans(className, "otherNamespace", 1, true)[0],
+			},
+		},
 		"ErrorWhenNoPlansSpecified": {
 			instance: &sc.ServiceInstance{
 				ObjectMeta: metav1.ObjectMeta{Name: "instance", Namespace: "dummy"},


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:
In case when SeriveInstance has no plan given, webhook tries to find a default plan for a specific serviceClass.
Bug in ServiceInstance webhook makes it impossible to find such a plan if there are more ServiceClass (with the same name) in other namespaces.

**Which issue(s) this PR fixes** 
#2856 

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
