### PR TITLE
switch CRDs to v1

### DIFF
--- a/charts/catalog/templates/crds/clusterservicebroker.yaml
+++ b/charts/catalog/templates/crds/clusterservicebroker.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterservicebrokers.servicecatalog.k8s.io
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Cluster
   names:
     plural: clusterservicebrokers
@@ -16,15 +15,19 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: URL
-      type: string
-      JSONPath: .spec.url
-    - name: Status
-      type: string
-      JSONPath: .status.lastConditionState
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: URL
+        type: string
+        jsonPath: .spec.url
+      - name: Status
+        type: string
+        jsonPath: .status.lastConditionState
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/catalog/templates/crds/clusterserviceclass.yaml
+++ b/charts/catalog/templates/crds/clusterserviceclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterserviceclasses.servicecatalog.k8s.io
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Cluster
   names:
     plural: clusterserviceclasses
@@ -16,15 +15,19 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: External-Name
-      type: string
-      JSONPath: .spec.externalName
-    - name: Broker
-      type: string
-      JSONPath: .spec.clusterServiceBrokerName
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: External-Name
+        type: string
+        jsonPath: .spec.externalName
+      - name: Broker
+        type: string
+        jsonPath: .spec.clusterServiceBrokerName
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/catalog/templates/crds/clusterserviceplan.yaml
+++ b/charts/catalog/templates/crds/clusterserviceplan.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterserviceplans.servicecatalog.k8s.io
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Cluster
   names:
     plural: clusterserviceplans
@@ -16,18 +15,22 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: External-Name
-      type: string
-      JSONPath: .spec.externalName
-    - name: Broker
-      type: string
-      JSONPath: .spec.clusterServiceBrokerName
-    - name: Class
-      type: string
-      JSONPath: .spec.clusterServiceClassRef.name
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: External-Name
+        type: string
+        jsonPath: .spec.externalName
+      - name: Broker
+        type: string
+        jsonPath: .spec.clusterServiceBrokerName
+      - name: Class
+        type: string
+        jsonPath: .spec.clusterServiceClassRef.name
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/catalog/templates/crds/servicebinding.yaml
+++ b/charts/catalog/templates/crds/servicebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: servicebindings.servicecatalog.k8s.io
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Namespaced
   names:
     plural: servicebindings
@@ -16,18 +15,22 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: Service-Instance
-      type: string
-      JSONPath: .spec.instanceRef.name
-    - name: Secret-Name
-      type: string
-      JSONPath: .spec.secretName
-    - name: Status
-      type: string
-      JSONPath: .status.lastConditionState
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: Service-Instance
+        type: string
+        jsonPath: .spec.instanceRef.name
+      - name: Secret-Name
+        type: string
+        jsonPath: .spec.secretName
+      - name: Status
+        type: string
+        jsonPath: .status.lastConditionState
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/catalog/templates/crds/servicebroker.yaml
+++ b/charts/catalog/templates/crds/servicebroker.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: servicebrokers.servicecatalog.k8s.io
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Namespaced
   names:
     plural: servicebrokers
@@ -16,15 +15,19 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: URL
-      type: string
-      JSONPath: .spec.url
-    - name: Status
-      type: string
-      JSONPath: .status.lastConditionState
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: URL
+        type: string
+        jsonPath: .spec.url
+      - name: Status
+        type: string
+        jsonPath: .status.lastConditionState
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/catalog/templates/crds/serviceclass.yaml
+++ b/charts/catalog/templates/crds/serviceclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: serviceclasses.servicecatalog.k8s.io
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Namespaced
   names:
     plural: serviceclasses
@@ -16,15 +15,19 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: External-Name
-      type: string
-      JSONPath: .spec.externalName
-    - name: Broker
-      type: string
-      JSONPath: .spec.serviceBrokerName
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: External-Name
+        type: string
+        jsonPath: .spec.externalName
+      - name: Broker
+        type: string
+        jsonPath: .spec.serviceBrokerName
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/catalog/templates/crds/serviceinstance.yaml
+++ b/charts/catalog/templates/crds/serviceinstance.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: serviceinstances.servicecatalog.k8s.io
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Namespaced
   names:
     plural: serviceinstances
@@ -16,18 +15,22 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: Class
-      type: string
-      JSONPath: .status.userSpecifiedClassName
-    - name: Plan
-      type: string
-      JSONPath: .status.userSpecifiedPlanName
-    - name: Status
-      type: string
-      JSONPath: .status.lastConditionState
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: Class
+        type: string
+        jsonPath: .status.userSpecifiedClassName
+      - name: Plan
+        type: string
+        jsonPath: .status.userSpecifiedPlanName
+      - name: Status
+        type: string
+        jsonPath: .status.lastConditionState
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/catalog/templates/crds/serviceplan.yaml
+++ b/charts/catalog/templates/crds/serviceplan.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: serviceplans.servicecatalog.k8s.io
@@ -6,7 +6,6 @@ metadata:
     svcat: "true"
 spec:
   group: servicecatalog.k8s.io
-  version: v1beta1
   scope: Namespaced
   names:
     plural: serviceplans
@@ -16,18 +15,22 @@ spec:
     categories:
       - all
       - svcat
-  additionalPrinterColumns:
-    - name: External-Name
-      type: string
-      JSONPath: .spec.externalName
-    - name: Broker
-      type: string
-      JSONPath: .spec.serviceBrokerName
-    - name: Class
-      type: string
-      JSONPath: .spec.serviceClassRef.name
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
+  versions:
+    - additionalPrinterColumns:
+      - name: External-Name
+        type: string
+        jsonPath: .spec.externalName
+      - name: Broker
+        type: string
+        jsonPath: .spec.serviceBrokerName
+      - name: Class
+        type: string
+        jsonPath: .spec.serviceClassRef.name
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
+      name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/cmd/webhook/server/options.go
+++ b/cmd/webhook/server/options.go
@@ -26,16 +26,18 @@ import (
 )
 
 const (
-	certDirectory            = "/var/run/service-catalog-webhook"
-	defaultWebhookServerPort = 8444
-	defaultHealthzServerPort = 8080
+	certDirectory                       = "/var/run/service-catalog-webhook"
+	defaultWebhookServerPort            = 8444
+	defaultHealthzServerPort            = 8080
+	defaultControllerManagerMetricsPort = 8082
 )
 
 // WebhookServerOptions holds configuration for mutating/validating webhook server.
 type WebhookServerOptions struct {
-	SecureServingOptions  *genericserveroptions.SecureServingOptions
-	ReleaseName           string
-	HealthzServerBindPort int
+	SecureServingOptions         *genericserveroptions.SecureServingOptions
+	ReleaseName                  string
+	HealthzServerBindPort        int
+	ControllerManagerMetricsPort int
 }
 
 // NewWebhookServerOptions creates a new WebhookServerOptions with a default settings.
@@ -54,6 +56,7 @@ func NewWebhookServerOptions() *WebhookServerOptions {
 // AddFlags adds flags for a WebhookServerOptions to the specified FlagSet.
 func (s *WebhookServerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.HealthzServerBindPort, "healthz-server-bind-port", defaultHealthzServerPort, "The port on which to serve HTTP  /healthz endpoint")
+	fs.IntVar(&s.ControllerManagerMetricsPort, "controller-manager-metrics-bind-port", defaultControllerManagerMetricsPort, "The address the metric endpoint binds to")
 
 	s.SecureServingOptions.AddFlags(fs)
 	utilfeature.DefaultMutableFeatureGate.AddFlag(fs)

--- a/cmd/webhook/server/webhook.go
+++ b/cmd/webhook/server/webhook.go
@@ -83,7 +83,8 @@ func run(opts *WebhookServerOptions, stopCh <-chan struct{}) error {
 		return fmt.Errorf("while waiting for ready Service Catalog CRDs: %v", err)
 	}
 
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := manager.New(cfg, manager.Options{
+		MetricsBindAddress: fmt.Sprintf(":%d", opts.ControllerManagerMetricsPort)})
 	if err != nil {
 		return errors.Wrap(err, "while set up overall controller manager for webhook server")
 	}


### PR DESCRIPTION
This PR is a 
 - [ ] Feature Implementation
 - [x] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

service-catalog chart contains CustomResourceDefinition manifests in API group apiextensions.k8s.io/v1beta1 that is deprecated in v1.16 in favor of apiextensions.k8s.io/v1.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
