### PR TITLE
helm: add global affinity,nodeSelector,podLabels and tolerations params

### DIFF
--- a/charts/catalog/Chart.yaml
+++ b/charts/catalog/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: catalog
 description: service-catalog webhook server and controller-manager helm chart
-version: 0.3.1
+version: 0.3.2

--- a/charts/catalog/README.md
+++ b/charts/catalog/README.md
@@ -76,9 +76,13 @@ chart and their default values.
 | `rbacEnable` | If true, create & use RBAC resources | `true` |
 | `originatingIdentityEnabled` | Whether the OriginatingIdentity feature should be enabled | `true` |
 | `persistence.storageClass` | Define the storageclass use by pvc | `null` |
+| `affinity`  | Affinity settings ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)) | `{}` |
 | `asyncBindingOperationsEnabled` | Whether or not alpha support for async binding operations is enabled | `false` |
 | `namespacedServiceBrokerDisabled` | Whether or not alpha support for namespace scoped brokers is disabled | `false` |
+| `nodeSelector` | Node labels for pod assignment (global parameter for all pods) | `{}` |
+| `podLabels`  | Additional pod labels to include for all pods | `{}` |
 | `priorityClassName` | Define PriorityClass for pods | "" |
+| `tolerations` | Tolerations for pod assignment | `[]` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/charts/catalog/templates/cleaner-job.yaml
+++ b/charts/catalog/templates/cleaner-job.yaml
@@ -81,12 +81,18 @@ spec:
   template:
     metadata:
       labels:
+        {{- if .Values.podLabels }}
+        {{- tpl (toYaml .Values.podLabels) $ | nindent 8 }}
+        {{- end }}
         cleaner-job: "true"
         app: {{ template "fullname" . }}-clean-job
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
 {{- with .Values.securityContext }}
       securityContext:
 {{ toYaml . | indent 8 }}
@@ -109,3 +115,14 @@ spec:
           - {{ template "fullname" . }}-controller-manager
           - --webhook-configurations
           - {{ template "fullname" . }}-webhook {{ template "fullname" . }}-validating-webhook
+{{- with .Values.affinity }}
+      affinity: {{- tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/charts/catalog/templates/controller-manager-deployment.yaml
+++ b/charts/catalog/templates/controller-manager-deployment.yaml
@@ -18,10 +18,13 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: "{{ .Values.controllerManager.enablePrometheusScrape }}"
-      {{ if .Values.controllerManager.annotations }}
+      {{- if .Values.controllerManager.annotations }}
 {{ toYaml .Values.controllerManager.annotations | indent 8 }}
       {{- end }}
       labels:
+        {{- if .Values.podLabels }}
+        {{- tpl (toYaml .Values.podLabels) $ | nindent 8 }}
+        {{- end }}
         app: {{ template "fullname" . }}-controller-manager
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
@@ -131,7 +134,14 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         {{- end }}
-      {{ if .Values.controllerManager.nodeSelector }}
+{{- with .Values.affinity }}
+      affinity: {{- tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
+      {{- if or .Values.controllerManager.nodeSelector .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.controllerManager.nodeSelector | indent 8 }}
-      {{ end }}
+{{ toYaml (mustMerge .Values.controllerManager.nodeSelector .Values.nodeSelector) | indent 8 }}
+      {{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/charts/catalog/templates/migration-job.yaml
+++ b/charts/catalog/templates/migration-job.yaml
@@ -106,12 +106,18 @@ spec:
   template:
     metadata:
       labels:
+        {{- if .Values.podLabels }}
+        {{- tpl (toYaml .Values.podLabels) $ | nindent 8 }}
+        {{- end }}
         migration-job: "true"
         app: {{ template "fullname" . }}-migration-job
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
 {{- with .Values.securityContext }}
       securityContext:
 {{ toYaml . | indent 8 }}
@@ -146,3 +152,14 @@ spec:
           volumeMounts:
           - name: storage
             mountPath: /data
+{{- with .Values.affinity }}
+      affinity: {{- tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/charts/catalog/templates/pre-migration-job.yaml
+++ b/charts/catalog/templates/pre-migration-job.yaml
@@ -120,12 +120,18 @@ spec:
   template:
     metadata:
       labels:
+        {{- if .Values.podLabels }}
+        {{- tpl (toYaml .Values.podLabels) $ | nindent 8 }}
+        {{- end }}
         migration-job: "true"
         app: {{ template "fullname" . }}-pre-migration-job
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
 {{- with .Values.securityContext }}
       securityContext:
 {{ toYaml . | indent 8 }}
@@ -156,3 +162,14 @@ spec:
           volumeMounts:
           - name: storage
             mountPath: /data
+{{- with .Values.affinity }}
+      affinity: {{- tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/charts/catalog/templates/webhook-deployment.yaml
+++ b/charts/catalog/templates/webhook-deployment.yaml
@@ -17,12 +17,15 @@ spec:
   template:
     metadata:
       labels:
+        {{- if .Values.podLabels }}
+        {{- tpl (toYaml .Values.podLabels) $ | nindent 8 }}
+        {{- end }}
         app: {{ template "fullname" . }}-webhook
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         releaseRevision: "{{ .Release.Revision }}"
         heritage: "{{ .Release.Service }}"
-      {{ if .Values.webhook.annotations }}
+      {{- if .Values.webhook.annotations }}
       annotations:
 {{ toYaml .Values.webhook.annotations | indent 8 }}
       {{- end }}
@@ -87,10 +90,17 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         {{- end }}
-      {{ if .Values.webhook.nodeSelector }}
+{{- with .Values.affinity }}
+      affinity: {{- tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
+      {{- if or .Values.webhook.nodeSelector .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.webhook.nodeSelector | indent 8 }}
-      {{ end }}
+{{ toYaml (mustMerge .Values.webhook.nodeSelector .Values.nodeSelector) | indent 8 }}
+      {{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
       volumes:
       - name: service-catalog-webhook-cert
         secret:

--- a/charts/catalog/values.yaml
+++ b/charts/catalog/values.yaml
@@ -20,7 +20,7 @@ webhook:
   # annotations is a collection of annotations to add to the webhook pods.
   annotations: {}
   # nodeSelector to apply to the webhook pods
-  nodeSelector:
+  nodeSelector: {}
   # healthcheck configures the readiness and liveliness probes for the webhook pod.
   healthcheck:
     enabled: true
@@ -59,7 +59,7 @@ controllerManager:
   # annotations is a collection of annotations to add to the controllerManager pod.
   annotations: {}
   # nodeSelector to apply to the controllerManager pods
-  nodeSelector:
+  nodeSelector: {}
   # healthcheck configures the readiness and liveliness probes for the controllerManager pod.
   healthcheck:
     enabled: true
@@ -108,6 +108,9 @@ controllerManager:
       # Available port in allowable range (e.g. 30000 - 32767 on minikube)
       # The TLS-enabled endpoint will be exposed here
       securePort: 30444
+
+affinity: {}
+
 # Whether the OriginatingIdentity feature should be enabled
 originatingIdentityEnabled: true
 # Whether the AsyncBindingOperations alpha feature should be enabled
@@ -132,7 +135,13 @@ persistence:
   ##
   storageClass:
 
+nodeSelector: {}
+
+podLabels: {}
+
 # Leverage a PriorityClass to ensure your pods survive resource shortages
 # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 # PriorityClass: system-cluster-critical
 priorityClassName: ""
+
+tolerations: []


### PR DESCRIPTION
Adds global affinity, nodeSelector, podLabels and tolerations parameters to catalog chart. nodeSelector for controller-manager and webhook deployments have a priority over global nodeSelector value.

* nodeSelector parameters for controller-manager and webhook aren't enough as job pods could not be scheduled to the same nodepool in case taints are present and trigger scale out of different nodepool

 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes-sigs/service-catalog/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
3. See our merge process https://github.com/kubernetes-sigs/service-catalog/blob/master/REVIEWING.md
-->

This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** 
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

Please leave this checklist in the PR comment so that maintainers can ensure a good PR.

Merge Checklist:
 - [ ] New feature 
   - [ ] Tests
   - [ ] Documentation
 - [ ] SVCat CLI flag
 - [ ] Server Flag for config
   - [ ] Chart changes
   - [ ] removing a flag by marking deprecated and hiding to avoid
         breaking the chart release and existing clients who provide a
         flag that will get an error when they try to update
